### PR TITLE
Support configurable remote cache locations

### DIFF
--- a/civicpy/__init__.py
+++ b/civicpy/__init__.py
@@ -1,12 +1,7 @@
 from .__version__ import __version__
 from pathlib import Path
 
-PROJECT_ROOT = Path(__file__).resolve().parent
-DATA_ROOT = PROJECT_ROOT / 'data'
-
-if not DATA_ROOT.exists():
-    DATA_ROOT.mkdir()
-
+REMOTE_MASTER_CACHE = "https://civicdb.org/downloads/civicpy_cache.pkl"
 
 def version():
     return __version__

--- a/civicpy/civic.py
+++ b/civicpy/civic.py
@@ -105,6 +105,16 @@ def load_cache():
         v.update()
     _build_coordinate_table(variants)
 
+
+def update_cache():
+    _get_elements_by_ids('evidence', allow_cached=False, get_all=True)
+    _get_elements_by_ids('gene', allow_cached=False, get_all=True)
+    _get_elements_by_ids('variant', allow_cached=False, get_all=True)
+    _get_elements_by_ids('assertion', allow_cached=False, get_all=True)
+    CACHE['full_cached'] = datetime.datetime.now()
+    save_cache()
+
+
 class CivicRecord:
 
     _SIMPLE_FIELDS = {'id', 'type'}
@@ -392,23 +402,28 @@ def get_cached(element_type, element_id):
     return CACHE.get(hash(r), False)
 
 
-def _has_all_cached_fresh(element):
-    s = '{}_all_cached'.format(pluralize(element))
+def _has_full_cached_fresh(delta=FRESH_DELTA):
+    s = 'full_cached'
     if CACHE.get(s, False):
-        return CACHE[s] + FRESH_DELTA > datetime.datetime.now()
+        return CACHE[s] + delta > datetime.datetime.now()
     return False
 
 
 def _get_elements_by_ids(element, id_list=[], allow_cached=True, get_all=False):
-    if allow_cached and not get_all:
-        cached = [get_cached(element, element_id) for element_id in id_list]
-        if all(cached):
+    if allow_cached:
+        if not CACHE:
+            load_cache()
+        if not _has_full_cached_fresh():
+            update_cache()
+        if not get_all:
+            cached = [get_cached(element, element_id) for element_id in id_list]
+            if all(cached):
+                logging.info(f'Loading {pluralize(element)} from cache')
+                return cached
+        else:
+            cached = [get_cached(element, element_id) for element_id in CACHE['{}_all_ids'.format(pluralize(element))]]
             logging.info(f'Loading {pluralize(element)} from cache')
             return cached
-    elif allow_cached and _has_all_cached_fresh(element):
-        cached = [get_cached(element, element_id) for element_id in CACHE['{}_all_ids'.format(pluralize(element))]]
-        logging.info(f'Loading {pluralize(element)} from cache')
-        return cached
     if id_list and get_all:
         raise ValueError('Please pass list of ids or use the get_all flag, not both.')
     if get_all:
@@ -421,7 +436,6 @@ def _get_elements_by_ids(element, id_list=[], allow_cached=True, get_all=False):
     response.raise_for_status()
     cls = get_class(element)
     elements = [cls(**x) for x in response.json()['results']]
-    CACHE['{}_all_cached'.format(pluralize(element))] = datetime.datetime.now()
     CACHE['{}_all_ids'.format(pluralize(element))] = [x['id'] for x in response.json()['results']]
     return elements
 
@@ -549,7 +563,7 @@ def _build_coordinate_table(variants):
 
 
 def get_all_variants(allow_cached=True):
-    precached = _has_all_cached_fresh('variants')
+    precached = _has_full_cached_fresh()
     variants = _get_all_genes_and_variants(allow_cached)['variants']
     if not (precached and allow_cached):
         _build_coordinate_table(variants)

--- a/civicpy/civic.py
+++ b/civicpy/civic.py
@@ -4,13 +4,12 @@ import logging
 import datetime
 import pandas as pd
 import pickle
+import os
 from collections import defaultdict, namedtuple
-from civicpy import DATA_ROOT
+from civicpy import REMOTE_MASTER_CACHE
 
 
 CACHE = dict()
-
-CACHE_FILE = DATA_ROOT / 'CACHE.pkl'
 
 COORDINATE_TABLE = None
 COORDINATE_TABLE_START = None
@@ -79,13 +78,21 @@ def get_class(element_type):
     return cls
 
 
+def read_cache_file_location():
+    if 'CIVICPY_CACHE_FILE' in os.environ and os.environ['CIVICPY_CACHE_FILE'] is not None:
+        return os.environ['CIVICPY_CACHE_FILE']
+    else:
+        return REMOTE_MASTER_CACHE
+
+
 def save_cache():
-    with open(CACHE_FILE, 'wb') as pf:
-        pickle.dump(CACHE, pf)
+    if 'CIVICPY_CACHE_FILE' in os.environ and os.environ['CIVICPY_CACHE_FILE'] is not None:
+        with open(os.environ['CIVICPY_CACHE_FILE'], 'wb') as pf:
+            pickle.dump(CACHE, pf)
 
 
-def load_cache():
-    with open(CACHE_FILE, 'rb') as pf:
+def load_cache(update_delta=FRESH_DELTA):
+    with open(read_cache_file_location(), 'rb') as pf:
         old_cache = pickle.load(pf)
     c = dict()
     variants = set()

--- a/civicpy/tests/test_civic.py
+++ b/civicpy/tests/test_civic.py
@@ -8,11 +8,7 @@ ELEMENTS = [
 
 
 def setup_module():
-    try:
-        civic.load_cache()
-    except FileNotFoundError:
-        pass
-    civic.get_all_variants()
+    civic.get_all_variants(allow_cached=False)
 
 
 @pytest.fixture(scope="module", params=ELEMENTS)


### PR DESCRIPTION
The location of the cache is set via the `CIVICPY_CACHE_FILE` env variable. Otherwise it defaults to a location on civicdb.org.

The new method `update_cache` will fetch all records and save the pkl to the `CIVICPY_CACHE_FILE` location. This method will be used when creating and updating the remote master pkl on civicdb.org.

The tests have been updated to not allow caching.

Closes #17 