### PR TITLE
Update the VCFWriter to handle indels

### DIFF
--- a/civicpy/civic.py
+++ b/civicpy/civic.py
@@ -399,6 +399,18 @@ class Variant(CivicRecord):
     def gene(self):
         return _get_element_by_id('gene', self.gene_id)
 
+    @property
+    def is_insertion(self):
+        return self.coordinates.reference_bases is None and self.coordinates.variant_bases is not None
+
+    @property
+    def is_deletion(self):
+        return self.coordinates.reference_bases is not None and (self.coordinates.variant_bases is None or self.coordinates.variant_bases == '-')
+
+    @property
+    def is_valid_for_vcf(self):
+        return self.coordinates.chromosome and self.coordinates.start and (self.coordinates.reference_bases or self.coordinates.variant_bases)
+
 
 class Gene(CivicRecord):
     _SIMPLE_FIELDS = CivicRecord._SIMPLE_FIELDS.union(

--- a/civicpy/civic.py
+++ b/civicpy/civic.py
@@ -407,9 +407,34 @@ class Variant(CivicRecord):
     def is_deletion(self):
         return self.coordinates.reference_bases is not None and (self.coordinates.variant_bases is None or self.coordinates.variant_bases == '-')
 
-    @property
-    def is_valid_for_vcf(self):
-        return self.coordinates.chromosome and self.coordinates.start and (self.coordinates.reference_bases or self.coordinates.variant_bases)
+    def is_valid_for_vcf(self, emit_warnings=False):
+        if self.coordinates.chromosome2 or self.coordinates.start2 or self.coordinates.stop2:
+            warning = "Variant {} has a second set of coordinates. Skipping".format(self.id)
+        if self.coordinates.chromosome and self.coordinates.start and (self.coordinates.reference_bases or self.coordinates.variant_bases):
+            if self._valid_ref_bases:
+                if self._valid_alt_bases:
+                    return True
+                else:
+                    warning = "Unsupported variant base(s) for variant {}. Skipping.".format(self.id)
+            else:
+                warning = "Unsupported reference base(s) for variant {}. Skipping.".format(self.id)
+        else:
+            warning = "Incomplete coordinates for variant {}. Skipping.".format(self.id)
+        if emit_warnings:
+            logging.warning(warning)
+        return False
+
+    def _valid_ref_bases(self):
+        if self.coordinates.reference_bases is not None:
+            return True
+        else:
+            return all([c.upper() in ['A', 'C', 'G', 'T', 'N'] for c in self.coordinates.reference_bases])
+
+    def _valid_alt_bases(self):
+        if self.coordinates.variant_bases is not None:
+            return all([c.upper() in ['A', 'C', 'G', 'T', 'N', '*', '-'] for c in self.coordinates.variant_bases])
+        else:
+            return True
 
 
 class Gene(CivicRecord):

--- a/civicpy/cli.py
+++ b/civicpy/cli.py
@@ -1,13 +1,17 @@
 import click
 from civicpy import LOCAL_CACHE_PATH, civic
+from civicpy.exports import VCFWriter
 
 
-@click.group()
+CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
+
+
+@click.group(context_settings=CONTEXT_SETTINGS)
 def cli():
     pass
 
 
-@cli.command()
+@cli.command(context_settings=CONTEXT_SETTINGS)
 @click.option('--soft/--hard', default=True,
               help='Hard-update from live API (slow) or \
               soft-update from daily precache (fast; default)')
@@ -18,6 +22,20 @@ def update(soft, cache_save_path):
     """Updates CIViC content from server and stores to local cache file"""
     civic.update_cache(from_remote_cache=soft, local_cache_path=cache_save_path)
 
+@cli.command(context_settings=CONTEXT_SETTINGS)
+@click.option('-v', '--vcf-file-path', required=True,
+              help="The file path to write the VCF to.")
+@click.option('-i', '--include-status', required=True, multiple=True, type=click.Choice(['accepted', 'submitted', 'rejected']),
+              help="Limits the variants and annotations in the VCF to only the ones that match the given statuses. \
+              May be specified more than once.")
+def create_vcf(vcf_file_path, include_status):
+    """Create a VCF file of CIViC variants"""
+    with open(vcf_file_path, "w") as fh:
+        writer = VCFWriter(fh)
+        for variant in civic.get_all_variants(include_status=include_status):
+            if variant.is_valid_for_vcf():
+                writer.addrecord(variant)
+        writer.writerecords()
 
 if __name__ == '__main__':
     cli()

--- a/civicpy/exports.py
+++ b/civicpy/exports.py
@@ -7,51 +7,6 @@ import logging
 import requests
 
 
-class SequenceOntologyReader():
-
-    def __init__(self, url='https://raw.githubusercontent.com/The-Sequence-Ontology/SO-Ontologies/master/so.obo'):
-        self.url = url
-        self.graph = obonet.read_obo(url)
-        assert networkx.is_directed_acyclic_graph(self.graph)
-        self.ancestor_cache = dict()
-
-    def get_child_ids(self, id_):
-        return [x for x in self.graph.predecessors(id_)]  # I know. It looks wrong, but its not.
-
-    def get_parent_ids(self, id_):
-        return [x for x in self.graph.successors(id_)]    # I know. It looks wrong, but its not.
-
-    def same_or_has_ancestor(self, id_, ancestor_id):
-        if id_ == ancestor_id:
-            return True
-        key = (id_, ancestor_id)
-        cached = self.ancestor_cache.get(key, None)
-        if cached is not None:
-            return cached
-        parents = self.get_parent_ids(id_)
-        if not parents:
-            self.ancestor_cache[key] = False
-            return False
-        result = any([self.same_or_has_ancestor(parent, ancestor_id) for parent in parents])
-        self.ancestor_cache[key] = result
-        return result
-
-    def same_or_has_descendant(self, id_, descendant_id):
-        if id_ == descendant_id:
-            return True
-        key = (id_, descendant_id)
-        cached = self.ancestor_cache.get(key, None)
-        if cached is not None:
-            return cached
-        children = self.get_child_ids(id_)
-        if not children:
-            self.ancestor_cache[key] = False
-            return False
-        result = any([self.same_or_has_descendant(child, descendant_id) for child in children])
-        self.ancestor_cache[key] = result
-        return result
-
-
 class VCFWriter(DictWriter):
     SPECIAL_CHARACTERS = {
         " ": r'\x20',
@@ -100,8 +55,6 @@ class VCFWriter(DictWriter):
         'INFO'
     ]
 
-    VALID_VARIANTS = dict()
-
     SUPPORTED_VERSIONS = [4.2]
 
     VCF_RESERVED_FIELDS = {
@@ -125,8 +78,6 @@ class VCFWriter(DictWriter):
         '1000G'
     }
 
-    SO_READER = SequenceOntologyReader()
-
     def __init__(self, f, version=4.2):
         self._f = f
         assert version in VCFWriter.SUPPORTED_VERSIONS  # Supported VCF versions
@@ -144,15 +95,15 @@ class VCFWriter(DictWriter):
 
     def addrecord(self, civic_record):
         if isinstance(civic_record, civic.Evidence) or isinstance(civic_record, civic.Assertion):
-            self._validate_variant(civic_record.variant)
-            self._add_variant_record(civic_record.variant)
+            if civic_record.variant.is_valid_for_vcf(emit_warnings=True):
+                self._add_variant_record(civic_record.variant)
         elif isinstance(civic_record, civic.Gene):
             for variant in civic_record.variants:
-                self._validate_variant(variant)
-                self._add_variant_record(variant)
+                if civic_record.variant.is_valid_for_vcf(emit_warnings=True):
+                    self._add_variant_record(variant)
         elif isinstance(civic_record, civic.Variant):
-            self._validate_variant(civic_record)
-            self._add_variant_record(civic_record)
+            if civic_record.is_valid_for_vcf(emit_warnings=True):
+                self._add_variant_record(civic_record)
         else:
             raise ValueError('Expected a CIViC Variant, Assertion or Evidence record.')
 
@@ -211,9 +162,6 @@ class VCFWriter(DictWriter):
                 'REF':    ref,
                 'ALT':    alt,
             }
-            assert all([c.upper() in ['A', 'C', 'G', 'T', 'N'] for c in out_dict['REF']])
-            assert all([c.upper() in ['A', 'C', 'G', 'T', 'N', '*', '-'] for c in out_dict['ALT']]), \
-                f'observed incompatible alt allele in {evidence.variant}'
 
             info_dict = {
                 'GN': variant.gene.name,
@@ -335,113 +283,6 @@ class VCFWriter(DictWriter):
         s.extend([f'{k}={v}' for k, v in kwargs])
         out = ','.join(s)
         self._f.write(f'##INFO=<{out}>\n')
-
-    def _validate_variant(self, variant):
-        valid = self.VALID_VARIANTS.get(variant, None)
-        if valid is None:
-            valid = self._validate_sequence_variant(variant)
-        if not valid:
-            logging.info(f'{variant} is invalid for VCF.')
-        return valid
-
-    def _validate_sequence_variant(self, variant):
-        # Requires all types to have SO_IDs
-        types = variant.types
-        for variant_type in types:
-            if not variant_type.so_id.startswith('SO:'):
-                return self._cache_variant_validation(variant, False)
-
-        # Filter types if multiple direct lineage to most specific, remove non-variant types
-        type_len = len(types)
-        simplified_types = list()
-        for i in range(type_len):
-            remove = False
-            try:
-                sequence_variant = self.SO_READER.same_or_has_ancestor(types[i].so_id, 'SO:0001060')
-            except networkx.NetworkXError as e:
-                logging.warning(f'Error for variant {variant}: {e.args[0]}')
-                return self._cache_variant_validation(variant, False)
-            if not sequence_variant:
-                continue
-            for j in range(type_len):
-                if i == j:
-                    continue
-                if types[i].id == types[j].id and i > j:
-                    remove = True
-                elif self.SO_READER.same_or_has_descendant(types[i].so_id, types[j].so_id):
-                    remove = True
-            if remove:
-                logging.warning(f'Simplifying redundant type {types[i].name} in {variant}')
-                continue
-            simplified_types.append(types[i])
-        types = simplified_types
-
-        valid = self._validate_coordinates(variant, types)
-
-        # Requires at least one variant type (other than filtered types above) to be specified by CIViC
-        return self._cache_variant_validation(variant, valid)
-
-    def _validate_coordinates(self, variant, types):
-        # If multiple types, requires exactly one to be structural type.
-        if not types:
-            return False
-
-        if len(types) > 1:
-            structural_types = [t for t in types if self.SO_READER.same_or_has_ancestor(t.so_id, 'SO:0001537')]
-            if len(structural_types) == 1:
-                types = structural_types
-            elif len(structural_types) > 1:
-                logging.warning(f'Variant {variant} has multiple structural types. Skipping.')
-                return False
-            else:
-                logging.warning(f'Variant {variant} has multiple types, none structural. Skipping.')
-                return False
-
-        variant_type = types[0]
-
-        # If type is a transcript variant, requires exactly one coordinate set with ref and alt
-        if self.SO_READER.same_or_has_ancestor(variant_type.so_id, 'SO:0001576'):
-            coordinates = variant.coordinates
-            valid_array = [bool(x) for x in [
-                coordinates.chromosome,
-                coordinates.start,
-                coordinates.stop,
-                coordinates.reference_bases,
-                coordinates.variant_bases,
-                not coordinates.chromosome2,
-                not coordinates.start2,
-                not coordinates.stop2
-            ]]
-            valid = all(valid_array) \
-                    and all([c.upper() in ['A', 'C', 'G', 'T'] for c in coordinates.variant_bases]) \
-                    and all([c.upper() in ['A', 'C', 'G', 'T'] for c in coordinates.reference_bases])
-            if not valid:
-                if sum(valid_array[:5]) == 0:
-                    # Nothing to do here. No inference is to be performed, and no coordinates are provided.
-                    logging.warning(f'Variant {variant} has a structural type but no coordinates. Skipping.')
-                elif sum(valid_array[:3]) + sum(valid_array[-3:]) == 6:
-                    if sum(valid_array[3:5]) == 0:
-                        # Here, neither ref nor alt is specified, as in ambiguous mutations for an amino acid.
-                        logging.warning(f'Variant {variant} has a structural type but no ref or alt. Skipping.')
-                    elif self.SO_READER.same_or_has_ancestor(variant_type.so_id, 'SO:0001589') or \
-                        self.SO_READER.same_or_has_ancestor(variant_type.so_id, 'SO:0001820') or \
-                        self.SO_READER.same_or_has_ancestor(variant_type.so_id, 'SO:0001587') or \
-                        self.SO_READER.same_or_has_ancestor(variant_type.so_id, 'SO:0002012'):
-                        # Here, one of ref or alt is specified, and is of a compatible variant type for an indel
-                        # These are allowed.
-                        valid = True
-                    else:
-                        raise ValueError(f'Unexpected type ({variant_type.name}) for variant ( {variant.site_link} ).')
-                else:
-                    raise ValueError(f'Unexpected coordinates for ( {variant.site_link} ).')
-            return self._cache_variant_validation(variant, valid)
-        else:
-            raise NotImplementedError(f'No logic to handle {variant_type.name} {variant}')
-            # TODO: handle non-transcript variants here. Currently aren't any that meet other criteria.
-
-    def _cache_variant_validation(self, variant, result):
-        self.VALID_VARIANTS[variant] = result
-        return result
 
     def _add_variant_record(self, variant_record):
         self.variant_records.add(variant_record)

--- a/civicpy/tests/test_exports.py
+++ b/civicpy/tests/test_exports.py
@@ -1,5 +1,5 @@
 import pytest
-from civicpy import exports
+from civicpy import exports, civic
 import io
 
 
@@ -12,15 +12,15 @@ def vcf_stream():
 def vcf_writer(vcf_stream):
     return exports.VCFWriter(vcf_stream)
 
+@pytest.fixture(scope="module")
+def v600e():
+    return civic.get_variant_by_id(12)
 
 class TestVcfExport(object):
 
-    @pytest.mark.skip(reason="Implementation under development")
-    def test_protein_altering(self, vcf_writer, caplog):
-        assert False
-        #TODO: get v600e from cache
+    #@pytest.mark.skip(reason="Implementation under development")
+    def test_protein_altering(self, vcf_writer, caplog, v600e):
         vcf_writer.addrecord(v600e)
         assert not caplog.records
-        state1 = len(vcf_writer.evidence_records)
-        assert state1 == len(v600e.evidence)
-        vcf_writer.addrecord()
+        assert len(vcf_writer.variant_records) == 1
+        vcf_writer.writerecords()


### PR DESCRIPTION
This PR also removes the validation of variants on the sequence ontology and instead simply validates the coordinates. A convenience function `is_valid_for_vcf` on added that can be called on a variant object to determine whether or not it can be represented in a VCF. This method also gets called when adding a variant to a VCFWriter object.