### PR TITLE
Update master remote cache pkl file path

### DIFF
--- a/civicpy/__init__.py
+++ b/civicpy/__init__.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import os
 
 REMOTE_CACHE_URL = os.getenv('CIVICPY_REMOTE_CACHE_URL', False) or \
-                   "https://civicdb.org/downloads/civicpy_cache.pkl"
+                   "https://civicdb.org/downloads/nightly/nightly-civicpy_cache.pkl"
 LOCAL_CACHE_PATH = os.getenv('CIVICPY_CACHE_FILE', False) or \
                    str(Path.home() / '.civicpy' / 'cache.pkl')
 CACHE_TIMEOUT_DAYS = os.getenv('CIVICPY_CACHE_TIMEOUT_DAYS', False) or 7


### PR DESCRIPTION
With https://github.com/griffithlab/civic-server/pull/541 the path to the remote pkl cache file on the CIViC box will change.