### PR TITLE
closes #59

### DIFF
--- a/civicpy/__version__.py
+++ b/civicpy/__version__.py
@@ -4,7 +4,7 @@ __url__ = 'http://civicpy.org'
 __major__ = '1'
 __minor__ = '0'
 __patch__ = '0'
-__meta_label__ = 'rc2'
+__meta_label__ = 'rc3'
 __short_version__ = f"{__major__}.{__minor__}"
 __version__ = f"{__short_version__}.{__patch__}"
 if __meta_label__:


### PR DESCRIPTION
In this PR:

- Messages to assist users in getting desired behavior on failed `load_cache`.
- Prevent clobbering of in-memory cache on failed `load_cache`.
- Prevent overwrite of local cache on failed `load_cache` or failed `update_cache`.