### PR TITLE
Documentation of coordinate search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+docs/.doctrees/
 
 # PyBuilder
 target/

--- a/civicpy/civic.py
+++ b/civicpy/civic.py
@@ -34,8 +34,21 @@ CIVIC_TO_PYCLASS = {
 }
 
 
-CoordinateQuery = namedtuple('CoordinateQuery', ['chr', 'start', 'stop', 'alt', 'key'], defaults=(None, None))
+_CoordinateQuery = namedtuple('CoordinateQuery', ['chr', 'start', 'stop', 'alt', 'key'], defaults=(None, None))
 
+
+class CoordinateQuery(_CoordinateQuery):  # Wrapping for documentation
+    """
+    A namedtuple with preset fields describing a genomic coordinate,
+    for use with coordinate-based queries of CIViC Variants.
+
+    :param str chr: A chromosome of value 1-23, X, Y
+    :param int start: The chromosomal start position in base coordinates (1-based)
+    :param int stop: The chromosomal stop position in base coordinates (1-based)
+    :param str optional alt: The alternate nucleotide(s) at the designated coordinates
+    :param Any optional key: A user-defined object linked to the coordinate
+    """
+    pass
 
 def pluralize(string):
     if string in UNMARKED_PLURALS:
@@ -862,21 +875,16 @@ def search_variants_by_coordinates(coordinate_query, search_mode='any'):
     """
     Search the cache for variants matching provided coordinates using the corresponding search mode.
 
-    :param coordinate_query: A civic CoordinateQuery object
-                        start: the genomic start coordinate of the query
-                        stop: the genomic end coordinate of the query
-                        chr: the GRCh37 chromosome of the query (e.g. "7", "X")
-                        alt: the alternate allele at the coordinate [optional]
+    :param CoordinateQuery coordinate_query: Coordinates to query
 
-    :param search_mode: ['any', 'query_encompassing', 'variant_encompassing', 'exact']
-                        any: any overlap between a query and a variant is a match
-                        query_encompassing: variants must fit within the coordinates of the query
-                        variant_encompassing: variants must encompass the coordinates of the query
-                        exact: variants must match coordinates precisely, as well as alternate
-                               allele, if provided
-                        search_mode is 'exact' by default
+    :param any,query_encompassing,variant_encompassing,exact search_mode:
+                *any* : any overlap between a query and a variant is a match\n
+                *query_encompassing* : CIViC variant records must fit within the coordinates of the query\n
+                *record_encompassing* : CIViC variant records must encompass the coordinates of the query\n
+                *exact* : variants must match coordinates precisely, as well as alternate allele, if provided\n
+                search_mode is *exact* by default
 
-    :return:            Returns a list of variant hashes matching the coordinates and search_mode
+    :return:    Returns a list of variant hashes matching the coordinates and search_mode
     """
     get_all_variants()
     ct = COORDINATE_TABLE
@@ -919,21 +927,16 @@ def bulk_search_variants_by_coordinates(sorted_queries, search_mode='any'):
     An interator to search the cache for variants matching the set of sorted coordinates and yield
     matches corresponding to the search mode.
 
-    :param sorted_queries:  A list of civic CoordinateQuery objects, sorted by coordinate.
-                            start: the genomic start coordinate of the query
-                            stop: the genomic end coordinate of the query
-                            chr: the GRCh37 chromosome of the query (e.g. "7", "X")
-                            alt: the alternate allele at the coordinate [optional]
+    :param list[CoordinateQuery] sorted_queries: Sorted list of coordinates to query
 
-    :param search_mode: ['any', 'query_encompassing', 'variant_encompassing', 'exact']
-                        any: any overlap between a query and a variant is a match
-                        query_encompassing: CIViC variant records must fit within the coordinates of the query
-                        record_encompassing: CIViC variant records must encompass the coordinates of the query
-                        exact: variants must match coordinates precisely, as well as alternate
-                               allele, if provided
-                        search_mode is 'exact' by default
+    :param any,query_encompassing,variant_encompassing,exact search_mode:
+                *any* : any overlap between a query and a variant is a match\n
+                *query_encompassing* : CIViC variant records must fit within the coordinates of the query\n
+                *record_encompassing* : CIViC variant records must encompass the coordinates of the query\n
+                *exact* : variants must match coordinates precisely, as well as alternate allele, if provided\n
+                search_mode is *exact* by default
 
-    :yield:            Yields (query, match) tuples for each identified match
+    :yield:     Yields (query, match) tuples for each identified match
     """
 
     def is_sorted(prev_q, current_q):

--- a/civicpy/civic.py
+++ b/civicpy/civic.py
@@ -936,7 +936,7 @@ def bulk_search_variants_by_coordinates(sorted_queries, search_mode='any'):
                 *exact* : variants must match coordinates precisely, as well as alternate allele, if provided\n
                 search_mode is *exact* by default
 
-    :return:    returns a dictionary of result lists, keyed by query
+    :return:    returns a dictionary of Match lists, keyed by query
     """
 
     def is_sorted(prev_q, current_q):

--- a/civicpy/civic.py
+++ b/civicpy/civic.py
@@ -936,7 +936,7 @@ def bulk_search_variants_by_coordinates(sorted_queries, search_mode='any'):
                 *exact* : variants must match coordinates precisely, as well as alternate allele, if provided\n
                 search_mode is *exact* by default
 
-    :yield:     Yields (query, match) tuples for each identified match
+    :return:    returns a dictionary of result lists, keyed by query
     """
 
     def is_sorted(prev_q, current_q):

--- a/docs/civic.rst
+++ b/docs/civic.rst
@@ -1,3 +1,5 @@
+.. py:module:: civic
+
 The **civic** module
 ======================
 
@@ -7,12 +9,12 @@ While these record objects can be initialized independently, the **civic** modul
 
 The **civic** module may be imported from **civicpy** at the top level::
 
-	>>>from civicpy import civic
+   >>>from civicpy import civic
 
 CIViC records
 -------------
 
-.. autoclass:: civic.CivicRecord
+.. autoclass:: CivicRecord
    :members:
 
    .. automethod:: __init__
@@ -31,7 +33,7 @@ CIViC record types
 
 The primary CIViC records are found on the CIViC advanced search page, and are fully-formed
 
-.. autoclass:: civic.Gene
+.. autoclass:: Gene
    :members:
 
    .. attribute:: description
@@ -58,7 +60,7 @@ The primary CIViC records are found on the CIViC advanced search page, and are f
 
 .. _HGNC Gene Symbol: https://www.genenames.org/
 
-.. autoclass:: civic.Variant
+.. autoclass:: Variant
 
        .. attribute:: allele_registry_id
 
@@ -153,9 +155,9 @@ The primary CIViC records are found on the CIViC advanced search page, and are f
 
 .. _Sequence Ontology: http://www.sequenceontology.org/
 
-.. autoclass:: civic.Evidence
+.. autoclass:: Evidence
 
-.. autoclass:: civic.Assertion
+.. autoclass:: Assertion
 
 CIViC attributes
 ~~~~~~~~~~~~~~~~
@@ -165,31 +167,47 @@ class for additional complex records beyond those mentioned above (e.g. diseases
 except as attached objects to non-:class:`CivicAttribute` :class:`CivicRecord` objects, and cannot be retrieved
 independently.
 
-.. class:: CivicAttribute
+.. autoclass:: CivicAttribute
 
 Getting records
 ---------------
 
+By ID
+~~~~~
+
 Records can be obtained by ID through a collection of functions provided in the `civic` module. :class:`Gene`
 objects can be queried by the following methods:
 
-.. automodule:: civic
-   :members: get_gene_by_id, get_genes_by_ids, get_all_genes, get_all_gene_ids
+.. autofunction:: get_gene_by_id
+.. autofunction:: get_genes_by_ids
+.. autofunction:: get_all_genes
+.. autofunction:: get_all_gene_ids
 
 Analogous methods exist for :class:`Variant`, :class:`Assertion`, and :class:`Evidence`:
 
-.. automodule:: civic
-   :members: get_variants_by_ids, get_variant_by_id, get_all_variants, get_all_variant_ids
-   :undoc-members:
-   :noindex:
+.. autofunction:: get_variants_by_ids
+.. autofunction:: get_variant_by_id
+.. autofunction:: get_all_variants
+.. autofunction:: get_all_variant_ids
 
-.. automodule:: civic
-   :members: get_assertions_by_ids, get_assertion_by_id, get_all_assertions, get_all_assertion_ids
-   :undoc-members:
-   :noindex:
+.. autofunction:: get_assertions_by_ids
+.. autofunction:: get_assertion_by_id
+.. autofunction:: get_all_assertions
+.. autofunction:: get_all_assertion_ids
 
-.. automodule:: civic
-   :members: get_all_evidence, get_all_evidence_ids
-   :undoc-members:
-   :noindex:
+.. autofunction:: get_all_evidence
+.. autofunction:: get_all_evidence_ids
 
+By Coordinate
+~~~~~~~~~~~~~
+
+Variant records can be searched by GRCh37 coordinates. To query specific genomic coordinates, you will
+need to construct a :class:`CoordinateQuery` object, and pass this query to the
+:func:`search_variants_by_coordinates` function. If you wish to query multiple genomic coordinates (e.g.
+a set of variants observed in a patient tumor), construct a sorted list of :class:`CoordinateQuery` objects
+(sorted by `chr`, `start`, `stop`, `alt`), and pass the list to the :func:`bulk_search_variants_by_coordinates`
+function.
+
+.. autoclass:: CoordinateQuery
+.. autofunction:: search_variants_by_coordinates
+.. autofunction:: bulk_search_variants_by_coordinates

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -54,7 +54,7 @@ This documentation describes how to get started with CIViCpy, the SDK, and makin
 knowledgebase.
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 3
 
    intro
    install

--- a/environment.yml
+++ b/environment.yml
@@ -7,4 +7,4 @@ dependencies:
   - sphinxjp.themes.basicstrap
   - Cython
   - pandas==0.24.1
-  - civicpy==1.0.0rc2
+  - civicpy==1.0.0rc3

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,11 @@ setup(
             'pytest-cov',
             'python-coveralls',
         ],
+        'docs': [
+            'sphinx',
+            'sphinxjp.themes.basicstrap',
+            'sphinxcontrib.programoutput'
+        ]
     },
     python_requires='>=3.7',
     entry_points={


### PR DESCRIPTION
This PR documents coordinate search, and also includes a couple of small changes to support documentation workflow:

- Specify documentation dependencies
- Set module scope for Sphinx, instead of restating module throughout `civic.rst1` document