### PR TITLE
Gene provenance

### DIFF
--- a/civicpy/__version__.py
+++ b/civicpy/__version__.py
@@ -4,7 +4,7 @@ __url__ = 'http://civicpy.org'
 __major__ = '1'
 __minor__ = '0'
 __patch__ = '0'
-__meta_label__ = 'rc3'
+__meta_label__ = 'rc4'
 __short_version__ = f"{__major__}.{__minor__}"
 __version__ = f"{__short_version__}.{__patch__}"
 if __meta_label__:
@@ -12,4 +12,4 @@ if __meta_label__:
 __authors__ = ['Alex H. Wagner', 'Susanna Kiwala']
 __author_email__ = 'help@civicpy.org'
 __license__ = 'MIT'
-__copyright__ = 'Copyright 2018-2019 The Griffith Lab'
+__copyright__ = 'Copyright 2018-2020 The Griffith Lab'

--- a/civicpy/civic.py
+++ b/civicpy/civic.py
@@ -534,7 +534,7 @@ class Gene(CivicRecord):
     _COMPLEX_FIELDS = CivicRecord._COMPLEX_FIELDS.union({
         'aliases',
         # 'errors',                 # TODO: Add support for these fields in advanced search endpoint
-        # 'lifecycle_actions',
+        'lifecycle_actions',
         # 'provisional_values',
         # 'sources',
         'variants'
@@ -742,7 +742,6 @@ class LifecycleAction(CivicAttribute):
     _COMPLEX_FIELDS = CivicAttribute._COMPLEX_FIELDS.union(_OPTIONAL_FIELDS)
 
 
-
 class BaseLifecycleAction(CivicAttribute):
     _SIMPLE_FIELDS = CivicAttribute._SIMPLE_FIELDS.union({
         'timestamp'
@@ -750,6 +749,19 @@ class BaseLifecycleAction(CivicAttribute):
     _COMPLEX_FIELDS = CivicAttribute._COMPLEX_FIELDS.union({
         'user'
     })
+
+    def __init__(self, **kwargs):
+        self._timestamp = None
+        super().__init__(**kwargs)
+
+    @property
+    def timestamp(self):
+        assert self._timestamp[-1] == 'Z'
+        return datetime.datetime.fromisoformat(self._timestamp[:-1])
+
+    @timestamp.setter
+    def timestamp(self, value):
+        self._timestamp = value
 
 
 class Submitted(BaseLifecycleAction):

--- a/civicpy/civic.py
+++ b/civicpy/civic.py
@@ -656,9 +656,9 @@ class User(CivicRecord):
         'linkedin_profile',
         'bio',
         'featured_expert',
-        'accepted_license',
-        'signup_complete',
-        'affiliation'
+        # 'accepted_license',
+        # 'signup_complete',
+        # 'affiliation'
     })
 
     _OPTIONAL_FIELDS = CivicRecord._OPTIONAL_FIELDS.union({

--- a/civicpy/civic.py
+++ b/civicpy/civic.py
@@ -669,6 +669,19 @@ class User(CivicRecord):
 
     _COMPLEX_FIELDS = CivicRecord._COMPLEX_FIELDS.union(_OPTIONAL_FIELDS)
 
+    def __init__(self, **kwargs):
+        self._created_at = None
+        super().__init__(**kwargs)
+
+    @property
+    def created_at(self):
+        assert self._created_at[-1] == 'Z'
+        return datetime.datetime.fromisoformat(self._created_at[:-1])
+
+    @created_at.setter
+    def created_at(self, value):
+        self._created_at = value
+
 
 class Organization(CivicRecord):
     _SIMPLE_FIELDS = CivicRecord._SIMPLE_FIELDS.union({

--- a/civicpy/tests/test_civic.py
+++ b/civicpy/tests/test_civic.py
@@ -64,67 +64,67 @@ class TestEvidence(object):
 
     def test_get_all(self):
         evidence = civic.get_all_evidence()
-        assert len(evidence) == 6656
+        assert len(evidence) >= 6656
 
     def test_get_non_rejected(self):
         evidence = civic.get_all_evidence(include_status=['accepted', 'submitted'])
-        assert len(evidence) == 6519
+        assert len(evidence) >= 6519
 
     def test_get_accepted_only(self):
         evidence = civic.get_all_evidence(include_status=['accepted'])
-        assert len(evidence) == 3247
+        assert len(evidence) >= 3247
 
 
 class TestVariants(object):
 
     def test_get_all(self):
         variants = civic.get_all_variants()
-        assert len(variants) == 2396
+        assert len(variants) >= 2396
 
     def test_get_non_rejected(self):
         variants = civic.get_all_variants(include_status=['accepted', 'submitted'])
-        assert len(variants) == 2374
+        assert len(variants) >= 2374
 
     def test_get_accepted_only(self):
         variants = civic.get_all_variants(include_status=['accepted'])
-        assert len(variants) == 1333
+        assert len(variants) >= 1333
 
 
 class TestVariantGroups(object):
 
     def test_get_all(self):
         variant_groups = civic.get_all_variant_groups()
-        assert len(variant_groups) == 25
+        assert len(variant_groups) >= 25
 
 
 class TestAssertions(object):
 
     def test_get_all(self):
         assertions = civic.get_all_assertions()
-        assert len(assertions) == 28
+        assert len(assertions) >= 28
 
     def test_get_non_rejected(self):
         assertions = civic.get_all_assertions(include_status=['accepted', 'submitted'])
-        assert len(assertions) == 24
+        assert len(assertions) >= 24
 
     def test_get_accepted_only(self):
         assertions = civic.get_all_assertions(include_status=['accepted'])
-        assert len(assertions) == 16
+        assert len(assertions) >= 16
 
 
 class TestGenes(object):
 
     def test_get_all(self):
         genes = civic.get_all_genes()
-        assert len(genes) == 407
+        assert len(genes) >= 407
 
     def test_get_non_rejected(self):
         genes = civic.get_all_genes(include_status=['accepted', 'submitted'])
-        assert len(genes) == 402
+        assert len(genes) >= 402
 
     def test_get_accepted_only(self):
         genes = civic.get_all_genes(include_status=['accepted'])
-        assert len(genes) == 322
+        assert len(genes) >= 322
 
 
 class TestCoordinateSearch(object):

--- a/docs/civic.rst
+++ b/docs/civic.rst
@@ -220,6 +220,97 @@ a given action on a record.
 .. autoclass:: User
    :show-inheritance:
 
+   .. attribute:: name
+
+      The user-defined full name for the :class:`User`.
+
+   .. attribute:: username
+
+      The user-defined system name for the :class:`User`.
+
+   .. attribute:: role
+
+      The CIViC role held by a :class:`User`: Administrator, Editor, or Curator.
+
+   .. attribute:: area_of_expertise
+
+      An optional attribute for a :class:`User` indicating their perspective as a CIViC participant:
+         Research Scientist, Clinical Scientist, or Patient Advocate.
+
+   .. attribute:: orcid
+
+      An optional attribute for a :class:`User` indicating their `ORCiD <https://orcid.org/>`_.
+
+   .. attribute:: display_name
+
+      This attribute is populated with the first non-blank value from :attribute:`username`,
+         :attribute:`name`, :attribute:`email`, or :attribute:`id`.
+
+   .. attribute:: created_at
+
+      A `datetime` describing when the :class:`User` object was created.
+
+   .. attribute:: url
+
+      A string describing a personal website or blog for the :class:`User`.
+
+   .. attribute:: twitter_handle
+
+      A string describing the Twitter handle for a :class:`User`.
+
+   .. attribute:: facebook_profile
+
+      A string describing the Facebook profile ID for a :class:`User`.
+
+   .. attribute:: linkedin_profile
+
+      A string describing the Linked profile ID for a :class:`User`.
+
+   .. attribute:: bio
+
+      A short biography for a :class:`User`.
+
+   .. attribute:: featured_expert
+
+      A flag indicating if a user is a featured expert, and thus displayed on the CIViC
+         `domain experts <https://civicdb.org/about#domain-experts>`_ section
+
+.. autoclass:: Organization
+   :show-inheritance:
+
+   .. attribute:: name
+
+      The :class:`Organization` name.
+
+   .. attribute:: url
+
+      A URL for more information about the :class:`Organization`.
+
+   .. attribute:: description
+
+      A short text description about the :class:`Organization`.
+
+   .. attribute:: profile_image
+
+      A set of resource paths for the :class:`Organization` image at varying resolution.
+
+   .. attribute:: parent
+
+      A parent :class:`Organization`, if applicable.
+
+.. autoclass:: Country
+   :show-inheritance:
+
+   .. attribute:: iso
+
+      The `ISO 3166 Country Code <https://www.iso.org/iso-3166-country-codes.html>`_ for the
+      :class:`Country`.
+
+   .. attribute:: name
+
+      The full-text name for the :class:`Country`.
+
+
 Getting records
 ---------------
 

--- a/docs/civic.rst
+++ b/docs/civic.rst
@@ -56,6 +56,10 @@ The primary CIViC records are found on the CIViC advanced search page, and are f
 
            A list of :class:`Variant` records associated with this gene.
 
+   .. attribute:: lifecycle_actions
+
+      A :class:`LifecycleAction` container.
+
 .. _Entrez ID: https://www.ncbi.nlm.nih.gov/gene/
 
 .. _HGNC Gene Symbol: https://www.genenames.org/

--- a/environment.yml
+++ b/environment.yml
@@ -7,4 +7,4 @@ dependencies:
   - sphinxjp.themes.basicstrap
   - Cython
   - pandas==0.24.1
-  - civicpy==1.0.0rc3
+  - civicpy==1.0.0rc4


### PR DESCRIPTION
This PR addresses the final feature for #65. It also increments the CIViCpy release candidate version and structures timestamps as datetime objects instead of strings.

This is currently marked as a draft PR while documentation is being completed, but operational / non-documentation code should be viewed as complete.