### PR TITLE
Various bugfixes to coordinate search

### DIFF
--- a/civicpy/civic.py
+++ b/civicpy/civic.py
@@ -997,7 +997,7 @@ def search_variants_by_coordinates(coordinate_query, search_mode='any'):
                 *query_encompassing* : CIViC variant records must fit within the coordinates of the query\n
                 *record_encompassing* : CIViC variant records must encompass the coordinates of the query\n
                 *exact* : variants must match coordinates precisely, as well as alternate allele, if provided\n
-                search_mode is *exact* by default
+                search_mode is *any* by default
 
     :return:    Returns a list of variant hashes matching the coordinates and search_mode
     """
@@ -1049,7 +1049,7 @@ def bulk_search_variants_by_coordinates(sorted_queries, search_mode='any'):
                 *query_encompassing* : CIViC variant records must fit within the coordinates of the query\n
                 *record_encompassing* : CIViC variant records must encompass the coordinates of the query\n
                 *exact* : variants must match coordinates precisely, as well as alternate allele, if provided\n
-                search_mode is *exact* by default
+                search_mode is *any* by default
 
     :return:    returns a dictionary of Match lists, keyed by query
     """

--- a/civicpy/civic.py
+++ b/civicpy/civic.py
@@ -1111,7 +1111,7 @@ def bulk_search_variants_by_coordinates(sorted_queries, search_mode='any'):
         elif search_mode == 'exact' and q_start == c_start and q_stop == c_stop:
             q_alt = q.alt
             c_alt = c.alt
-            if not (q_alt and c_alt and q_alt != c_alt):
+            if not (q_alt and q_alt != c_alt):
                 append_match(matches, q, c)
         elif search_mode == 'query_encompassing' and q_start <= c_start and q_stop >= c_stop:
             append_match(matches, q, c)

--- a/civicpy/civic.py
+++ b/civicpy/civic.py
@@ -1027,7 +1027,7 @@ def search_variants_by_coordinates(coordinate_query, search_mode='any'):
     elif search_mode == 'variant_encompassing':
         match_idx = (start >= m_df.start) & (stop <= m_df.stop)
     elif search_mode == 'exact':
-        match_idx = (start == m_df.stop) & (stop == m_df.start)
+        match_idx = (start == m_df.start) & (stop == m_df.stop)
         if coordinate_query.alt:
             match_idx = match_idx & (coordinate_query.alt == m_df.alt)
     else:

--- a/civicpy/tests/test_civic.py
+++ b/civicpy/tests/test_civic.py
@@ -140,6 +140,21 @@ class TestCoordinateSearch(object):
         assertion_ids = [x.id for x in assertions]
         assert set(assertion_ids) >= set(v600e_assertion_ids)
 
+    def test_single_and_bulk_exact_return_same_variants(self):
+        query = CoordinateQuery('7', 140453136, 140453136, 'T')
+        variants_single = civic.search_variants_by_coordinates(query, search_mode='exact')
+        variants_bulk = civic.bulk_search_variants_by_coordinates([query], search_mode='exact')
+        assert len(variants_single) == 1
+        assert len(variants_bulk[query]) == 1
+        assert hash(variants_single[0]) == variants_bulk[query][0].v_hash
+
+        query = CoordinateQuery('7', 140453136, 140453137, 'TT')
+        variants_single = civic.search_variants_by_coordinates(query, search_mode='exact')
+        variants_bulk = civic.bulk_search_variants_by_coordinates([query], search_mode='exact')
+        assert len(variants_single) == 1
+        assert len(variants_bulk[query]) == 1
+        assert hash(variants_single[0]) == variants_bulk[query][0].v_hash
+
     def test_bulk_any_search_variants(self):
         sorted_queries = [
             CoordinateQuery('7', 140453136, 140453136, 'T'),

--- a/civicpy/tests/test_civic.py
+++ b/civicpy/tests/test_civic.py
@@ -156,7 +156,7 @@ class TestCoordinateSearch(object):
         ]
         search_results = civic.bulk_search_variants_by_coordinates(sorted_queries, search_mode='exact')
         assert len(search_results[sorted_queries[0]]) == 1
-        assert len(search_results[sorted_queries[1]]) == 2
+        assert len(search_results[sorted_queries[1]]) == 1
 
     def test_bulk_qe_search_variants(self):
         sorted_queries = [


### PR DESCRIPTION
The single exact coordinate query was broken because we were comparing the query start to the variant stop and the query stop to the variant start.

The bulk exact coordinate query wasn't matching the behavior of the single exact coordinate query because it was only comparing the alt if both the query and the variant had an alt set, which would return variants without an alt. 

The help text had the default value of `search_mode` incorrectly set to `exact`.