### PR TITLE
Fix bug in VCF coordinate retrieval for complex indels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ python:
 install:
   - pip install -e .[test]
 script:
+  - mkdir -p /home/travis/build/griffithlab/civicpy/civicpy/data
+  - wget -O /home/travis/build/griffithlab/civicpy/civicpy/data/test_cache.pkl https://civicdb.org/downloads/nightly/nightly-civicpy_cache.pkl
   - pytest --cov civicpy --cov-report term-missing
 after_success:
   - coveralls

--- a/civicpy/civic.py
+++ b/civicpy/civic.py
@@ -514,9 +514,9 @@ class Variant(CivicRecord):
 
     def _valid_ref_bases(self):
         if self.coordinates.reference_bases is not None:
-            return True
-        else:
             return all([c.upper() in ['A', 'C', 'G', 'T', 'N'] for c in self.coordinates.reference_bases])
+        else:
+            return True
 
     def _valid_alt_bases(self):
         if self.coordinates.variant_bases is not None:

--- a/civicpy/civic.py
+++ b/civicpy/civic.py
@@ -483,11 +483,17 @@ class Variant(CivicRecord):
 
     @property
     def is_insertion(self):
-        return self.coordinates.reference_bases is None and self.coordinates.variant_bases is not None
+        ref = self.coordinates.reference_bases
+        alt = self.coordinates.variant_bases
+        return (ref is None and alt is not None) or (ref is not None and alt is not None and len(ref) < len(alt))
 
     @property
     def is_deletion(self):
-        return self.coordinates.reference_bases is not None and (self.coordinates.variant_bases is None or self.coordinates.variant_bases == '-' or self.coordinates.variant_bases == '')
+        ref = self.coordinates.reference_bases
+        alt = self.coordinates.variant_bases
+        if alt is not None and (alt == '-' or alt == ''):
+            alt = None
+        return (ref is not None and alt is None) or (ref is not None and alt is not None and len(ref) > len(alt))
 
     def is_valid_for_vcf(self, emit_warnings=False):
         if self.coordinates.chromosome2 or self.coordinates.start2 or self.coordinates.stop2:

--- a/civicpy/civic.py
+++ b/civicpy/civic.py
@@ -499,8 +499,8 @@ class Variant(CivicRecord):
         if self.coordinates.chromosome2 or self.coordinates.start2 or self.coordinates.stop2:
             warning = "Variant {} has a second set of coordinates. Skipping".format(self.id)
         if self.coordinates.chromosome and self.coordinates.start and (self.coordinates.reference_bases or self.coordinates.variant_bases):
-            if self._valid_ref_bases:
-                if self._valid_alt_bases:
+            if self._valid_ref_bases():
+                if self._valid_alt_bases():
                     return True
                 else:
                     warning = "Unsupported variant base(s) for variant {}. Skipping.".format(self.id)

--- a/civicpy/exports.py
+++ b/civicpy/exports.py
@@ -151,6 +151,7 @@ class VCFWriter(DictWriter):
         ensembl_server = "https://grch37.rest.ensembl.org"
 
         # write them
+        rows = []
         for variant in sorted_records:
             if variant.coordinates.reference_build != 'GRCh37':
                 continue
@@ -161,7 +162,10 @@ class VCFWriter(DictWriter):
                     start = variant.coordinates.start
                     ext = "/sequence/region/human/{}:{}-{}".format(variant.coordinates.chromosome, start, start)
                     r = requests.get(ensembl_server+ext, headers={ "Content-Type" : "text/plain"})
-                    ref = r.text
+                    if variant.coordinates.reference_bases == None or variant.coordinates.reference_bases == '-' or variant.coordinates.reference_bases == '':
+                        ref = r.text
+                    else:
+                        ref = "{}{}".format(r.text, variant.coordinates.reference_bases)
                     alt = "{}{}".format(r.text, variant.coordinates.variant_bases)
                     csq_alt = variant.coordinates.variant_bases
             elif variant.is_deletion:
@@ -172,7 +176,10 @@ class VCFWriter(DictWriter):
                     ext = "/sequence/region/human/{}:{}-{}".format(variant.coordinates.chromosome, start, start)
                     r = requests.get(ensembl_server+ext, headers={ "Content-Type" : "text/plain"})
                     ref = "{}{}".format(r.text, variant.coordinates.reference_bases)
-                    alt = r.text
+                    if variant.coordinates.variant_bases == None or variant.coordinates.variant_bases == '-' or variant.coordinates.variant_bases == '':
+                        alt = r.text
+                    else:
+                        alt = "{}{}".format(r.text, variant.coordinates.variant_bases)
                     csq_alt = "-"
             else:
                 start = variant.coordinates.start
@@ -260,6 +267,8 @@ class VCFWriter(DictWriter):
             out_dict['INFO'] = ';'.join(out)
 
             super().writerow(out_dict)
+            rows.append(out_dict)
+        return rows
 
     def _write_meta_file_lines(self):
         self._f.write(f'##fileformat=VCFv{self.version}\n')

--- a/civicpy/tests/test_exports.py
+++ b/civicpy/tests/test_exports.py
@@ -54,8 +54,8 @@ class TestVcfExport(object):
         assert len(vcf_writer.variant_records) == 1
         out_dict = vcf_writer.writerecords()
         assert out_dict[0]['POS'] == '10183697'
-        assert out_dict[0]['REF'] == 'C'
-        assert out_dict[0]['ALT'] == 'CA'
+        assert out_dict[0]['REF'] == 'G'
+        assert out_dict[0]['ALT'] == 'GA'
 
     def test_simple_deletion(self, vcf_writer, caplog, v273fs):
         assert v273fs.is_deletion

--- a/civicpy/tests/test_exports.py
+++ b/civicpy/tests/test_exports.py
@@ -8,19 +8,81 @@ def vcf_stream():
     return io.StringIO()
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='function')
 def vcf_writer(vcf_stream):
     return exports.VCFWriter(vcf_stream)
 
+#snv
 @pytest.fixture(scope="module")
 def v600e():
     return civic.get_variant_by_id(12)
 
-class TestVcfExport(object):
+#simple insertion
+@pytest.fixture(scope="module")
+def a56fs():
+    return civic.get_variant_by_id(1785)
 
-    #@pytest.mark.skip(reason="Implementation under development")
+#simple deletion
+@pytest.fixture(scope="module")
+def v273fs():
+    return civic.get_variant_by_id(762)
+
+#complex insertion
+@pytest.fixture(scope="module")
+def v2444fs():
+    return civic.get_variant_by_id(137)
+
+#complex deletion
+@pytest.fixture(scope="module")
+def l158fs():
+    return civic.get_variant_by_id(2137)
+
+class TestVcfExport(object):
     def test_protein_altering(self, vcf_writer, caplog, v600e):
         vcf_writer.addrecord(v600e)
         assert not caplog.records
         assert len(vcf_writer.variant_records) == 1
-        vcf_writer.writerecords()
+        out_dict = vcf_writer.writerecords()
+        assert out_dict[0]['POS'] == '140453136'
+        assert out_dict[0]['REF'] == 'A'
+        assert out_dict[0]['ALT'] == 'T'
+
+    def test_simple_insertion(self, vcf_writer, caplog, a56fs):
+        assert a56fs.is_insertion
+        vcf_writer.addrecord(a56fs)
+        assert not caplog.records
+        assert len(vcf_writer.variant_records) == 1
+        out_dict = vcf_writer.writerecords()
+        assert out_dict[0]['POS'] == '10183698'
+        assert out_dict[0]['REF'] == 'C'
+        assert out_dict[0]['ALT'] == 'CA'
+
+    def test_simple_deletion(self, vcf_writer, caplog, v273fs):
+        assert v273fs.is_deletion
+        vcf_writer.addrecord(v273fs)
+        assert not caplog.records
+        assert len(vcf_writer.variant_records) == 1
+        out_dict = vcf_writer.writerecords()
+        assert out_dict[0]['POS'] == '47641432'
+        assert out_dict[0]['REF'] == 'GT'
+        assert out_dict[0]['ALT'] == 'G'
+
+    def test_complex_insertion(self, vcf_writer, caplog, v2444fs):
+        assert v2444fs.is_insertion
+        vcf_writer.addrecord(v2444fs)
+        assert not caplog.records
+        assert len(vcf_writer.variant_records) == 1
+        out_dict = vcf_writer.writerecords()
+        assert out_dict[0]['POS'] == '139390861'
+        assert out_dict[0]['REF'] == 'GG'
+        assert out_dict[0]['ALT'] == 'GTGT'
+
+    def test_complex_deletion(self, vcf_writer, caplog, l158fs):
+        assert l158fs.is_deletion
+        vcf_writer.addrecord(l158fs)
+        assert not caplog.records
+        assert len(vcf_writer.variant_records) == 1
+        out_dict = vcf_writer.writerecords()
+        assert out_dict[0]['POS'] == '10191480'
+        assert out_dict[0]['REF'] == 'TGAA'
+        assert out_dict[0]['ALT'] == 'TC'

--- a/civicpy/tests/test_exports.py
+++ b/civicpy/tests/test_exports.py
@@ -53,7 +53,7 @@ class TestVcfExport(object):
         assert not caplog.records
         assert len(vcf_writer.variant_records) == 1
         out_dict = vcf_writer.writerecords()
-        assert out_dict[0]['POS'] == '10183698'
+        assert out_dict[0]['POS'] == '10183697'
         assert out_dict[0]['REF'] == 'C'
         assert out_dict[0]['ALT'] == 'CA'
 


### PR DESCRIPTION
We should take a very close look at whether this logic in how to translate CIViC coordinates to VCF coordinates are correct. 5 examples for different types of variants are given in the test file. Special attention should be paid to the POS for each.