### PR TITLE
Use '*' as a wildcard for coordinate exact searches

### DIFF
--- a/civicpy/civic.py
+++ b/civicpy/civic.py
@@ -520,7 +520,7 @@ class Variant(CivicRecord):
 
     def _valid_alt_bases(self):
         if self.coordinates.variant_bases is not None:
-            return all([c.upper() in ['A', 'C', 'G', 'T', 'N', '*', '-'] for c in self.coordinates.variant_bases])
+            return all([c.upper() in ['A', 'C', 'G', 'T', 'N'] for c in self.coordinates.variant_bases])
         else:
             return True
 

--- a/civicpy/civic.py
+++ b/civicpy/civic.py
@@ -1006,7 +1006,10 @@ def search_variants_by_coordinates(coordinate_query, search_mode='any'):
                 *any* : any overlap between a query and a variant is a match\n
                 *query_encompassing* : CIViC variant records must fit within the coordinates of the query\n
                 *record_encompassing* : CIViC variant records must encompass the coordinates of the query\n
-                *exact* : variants must match coordinates precisely, as well as alternate allele, if provided\n
+                *exact* : variants must match coordinates precisely, as well as reference allele(s) and alternate allele(s).\n
+                          Use '*' in the coordinate_query as a wildcard for reference and/or alternate alleles.
+                          Using 'None' in the coordinate_query for reference or alternate alleles will only match
+                          variants that have no reference or alternate alleles, respectively (e.g. indels) \n
                 search_mode is *any* by default
 
     :return:    Returns a list of variant hashes matching the coordinates and search_mode
@@ -1038,10 +1041,14 @@ def search_variants_by_coordinates(coordinate_query, search_mode='any'):
         match_idx = (start >= m_df.start) & (stop <= m_df.stop)
     elif search_mode == 'exact':
         match_idx = (start == m_df.start) & (stop == m_df.stop)
-        if coordinate_query.alt:
+        if coordinate_query.alt is not None and coordinate_query.alt != '*':
             match_idx = match_idx & (coordinate_query.alt == m_df.alt)
-        if coordinate_query.ref:
+        elif coordinate_query.alt is None:
+            match_idx = match_idx & pd.isnull(m_df.alt)
+        if (coordinate_query.ref is not None and coordinate_query.ref != '*'):
             match_idx = match_idx & (coordinate_query.ref == m_df.ref)
+        elif coordinate_query.ref is None:
+            match_idx = match_idx & pd.isnull(m_df.ref)
     else:
         raise ValueError("unexpected search mode")
     var_digests = m_df.loc[match_idx,].v_hash.to_list()
@@ -1060,7 +1067,10 @@ def bulk_search_variants_by_coordinates(sorted_queries, search_mode='any'):
                 *any* : any overlap between a query and a variant is a match\n
                 *query_encompassing* : CIViC variant records must fit within the coordinates of the query\n
                 *record_encompassing* : CIViC variant records must encompass the coordinates of the query\n
-                *exact* : variants must match coordinates precisely, as well as alternate allele, if provided\n
+                *exact* : variants must match coordinates precisely, as well as reference allele(s) and alternate allele(s).\n
+                          Use '*' in the coordinate_query as a wildcard for reference and/or alternate alleles.
+                          Using 'None' in the coordinate_query for reference or alternate alleles will only match
+                          variants that have no reference or alternate alleles, respectively (e.g. indels) \n
                 search_mode is *any* by default
 
     :return:    returns a dictionary of Match lists, keyed by query
@@ -1125,7 +1135,7 @@ def bulk_search_variants_by_coordinates(sorted_queries, search_mode='any'):
             c_alt = c.alt
             q_ref = q.ref
             c_ref = c.ref
-            if (not (q_alt and q_alt != c_alt)) and (not (q_ref and q_ref != c_ref)):
+            if (not (q_alt != '*' and q_alt != c_alt)) and (not (q_ref != '*' and q_ref != c_ref)):
                 append_match(matches, q, c)
         elif search_mode == 'query_encompassing' and q_start <= c_start and q_stop >= c_stop:
             append_match(matches, q, c)

--- a/civicpy/tests/test_civic.py
+++ b/civicpy/tests/test_civic.py
@@ -139,7 +139,7 @@ class TestGenes(object):
 class TestCoordinateSearch(object):
 
     def test_search_assertions(self):
-        query = CoordinateQuery('7', 140453136, 140453136, 'T')
+        query = CoordinateQuery('7', 140453136, 140453136, 'T', '*')
         assertions = civic.search_assertions_by_coordinates(query)
         assertion_ids = [x.id for x in assertions]
         v600e_assertion_ids = (7, 10, 12, 20)
@@ -150,7 +150,7 @@ class TestCoordinateSearch(object):
         assert set(assertion_ids) >= set(v600e_assertion_ids)
 
     def test_single_and_bulk_exact_return_same_variants(self):
-        query = CoordinateQuery('7', 140453136, 140453136, 'T')
+        query = CoordinateQuery('7', 140453136, 140453136, 'T', '*')
         variants_single = civic.search_variants_by_coordinates(query, search_mode='exact')
         variants_bulk = civic.bulk_search_variants_by_coordinates([query], search_mode='exact')
         assert len(variants_single) == 1
@@ -164,7 +164,13 @@ class TestCoordinateSearch(object):
         assert len(variants_bulk[query]) == 1
         assert hash(variants_single[0]) == variants_bulk[query][0].v_hash
 
-        query = CoordinateQuery('7', 140453136, 140453137, 'TT')
+        query = CoordinateQuery('7', 140453136, 140453136, 'T', None)
+        variants_single = civic.search_variants_by_coordinates(query, search_mode='exact')
+        variants_bulk = civic.bulk_search_variants_by_coordinates([query], search_mode='exact')
+        assert len(variants_single) == 0
+        assert len(variants_bulk) == 0
+
+        query = CoordinateQuery('7', 140453136, 140453137, 'TT', '*')
         variants_single = civic.search_variants_by_coordinates(query, search_mode='exact')
         variants_bulk = civic.bulk_search_variants_by_coordinates([query], search_mode='exact')
         assert len(variants_single) == 1
@@ -178,6 +184,36 @@ class TestCoordinateSearch(object):
         assert len(variants_bulk[query]) == 1
         assert hash(variants_single[0]) == variants_bulk[query][0].v_hash
 
+        query = CoordinateQuery('7', 140453136, 140453137, 'TT', None)
+        variants_single = civic.search_variants_by_coordinates(query, search_mode='exact')
+        variants_bulk = civic.bulk_search_variants_by_coordinates([query], search_mode='exact')
+        assert len(variants_single) == 0
+        assert len(variants_bulk) == 0
+
+        query = CoordinateQuery('3', 10183706, 10183706, None, 'C')
+        variants_single = civic.search_variants_by_coordinates(query, search_mode='exact')
+        variants_bulk = civic.bulk_search_variants_by_coordinates([query], search_mode='exact')
+        assert len(variants_single) == 1
+        assert len(variants_bulk[query]) == 1
+        assert hash(variants_single[0]) == variants_bulk[query][0].v_hash
+
+        query = CoordinateQuery('3', 10183706, 10183706, 'T', 'C')
+        variants_single = civic.search_variants_by_coordinates(query, search_mode='exact')
+        variants_bulk = civic.bulk_search_variants_by_coordinates([query], search_mode='exact')
+        assert len(variants_single) == 1
+        assert len(variants_bulk[query]) == 1
+        assert hash(variants_single[0]) == variants_bulk[query][0].v_hash
+
+        query = CoordinateQuery('3', 10183706, 10183706, '*', 'C')
+        variants_single = civic.search_variants_by_coordinates(query, search_mode='exact')
+        variants_bulk = civic.bulk_search_variants_by_coordinates([query], search_mode='exact')
+        variants_single = list(map(lambda v: hash(v), variants_single))
+        variants_bulk = list(map(lambda v: v.v_hash, variants_bulk[query]))
+        assert len(variants_single) == 2
+        assert len(variants_bulk) == 2
+        assert sorted(variants_single) == sorted(variants_bulk)
+        assert sorted(variants_single) == sorted(variants_bulk)
+
     def test_bulk_any_search_variants(self):
         sorted_queries = [
             CoordinateQuery('7', 140453136, 140453136, 'T'),
@@ -189,8 +225,8 @@ class TestCoordinateSearch(object):
 
     def test_bulk_exact_search_variants(self):
         sorted_queries = [
-            CoordinateQuery('7', 140453136, 140453136, 'T'),
-            CoordinateQuery('7', 140453136, 140453137, 'TT'),
+            CoordinateQuery('7', 140453136, 140453136, 'T', '*'),
+            CoordinateQuery('7', 140453136, 140453137, 'TT', '*'),
             CoordinateQuery('7', 140453136, 140453136, 'T', 'A'),
             CoordinateQuery('7', 140453136, 140453137, 'TT', 'AC'),
         ]


### PR DESCRIPTION
Some variants will have None reference or alternate bases (e.g., indels). Previously, a None in the coordinate query would match any reference or alternate base (i.e., act as a de-facto wildcard). 

This PR changes this behavior so that using None in your query for your reference and/or alternate base will only match variants with no reference and/or alternate base. A new wildcard character `*` is introduced which can be used in the coordinate query for reference or alternate alleles and match any reference alleles or alternate alleles (including variants without reference or alternate alleles).