### PR TITLE
Patch for vcf_annotator2 to sanitize coordinate inputs

### DIFF
--- a/civicpy/civic.py
+++ b/civicpy/civic.py
@@ -437,11 +437,13 @@ class Variant(CivicRecord):
         self._assertions = []
         if evidence_items and not isinstance(evidence_items, list):
                 del(kwargs['evidence_items'])
+        coordinates = kwargs.get('coordinates')
+        if coordinates:
+            if coordinates.get('reference_bases') in ['', '-']:
+                coordinates['reference_bases'] = None
+            if coordinates.get('variant_bases') in ['', '-']:
+                coordinates['variant_bases'] = None
         super().__init__(**kwargs)
-        if self.coordinates.reference_bases in ['', '-']:
-            self.coordinates.reference_bases = None
-        if self.coordinatetes.variant_bases in ['', '-']:
-            self.coordinates.variant_bases = None
 
     @property
     def evidence_sources(self):

--- a/civicpy/tests/test_civic.py
+++ b/civicpy/tests/test_civic.py
@@ -104,6 +104,14 @@ class TestVariants(object):
         assert len(variants) == 1
         assert variants[0] == v600e
 
+    def test_sanitize_coordinate_bases(self):
+        variant1 = civic.get_variant_by_id(2696)
+        variant2 = civic.get_variant_by_id(558)
+        for v in variant1, variant2:
+            assert v.coordinates.reference_bases not in ['', '-']
+            assert v.coordinates.variant_bases not in ['', '-']
+
+
 class TestVariantGroups(object):
 
     def test_get_all(self):

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,8 @@ setup(
         'networkx',
         'pandas',
         'Click',
-        'PyVCF',
+        'vcfpy',
+        'pysam'
     ],
     extras_require={
         'test': [


### PR DESCRIPTION
Made a few small changes and added a test. It will only pass if you update the test cache (as this is designed to fix ahead of caching).