### PR TITLE
Add deprecation warnings to civic.get_all_x_ids methods

### DIFF
--- a/civicpy/civic.py
+++ b/civicpy/civic.py
@@ -9,6 +9,8 @@ from collections import defaultdict, namedtuple
 from civicpy import REMOTE_CACHE_URL, LOCAL_CACHE_PATH, CACHE_TIMEOUT_DAYS
 import requests
 from civicpy.exports import VCFWriter
+import deprecation
+from civicpy.__version__ import __version__
 from datetime import datetime, timedelta
 from backports.datetime_fromisoformat import MonkeyPatch
 MonkeyPatch.patch_fromisoformat()
@@ -1092,6 +1094,8 @@ def get_assertion_by_id(assertion_id):
     return get_assertions_by_ids([assertion_id])[0]
 
 
+@deprecation.deprecated(deprecated_in="1.1", removed_in="2.0",
+                        current_version=__version__)
 def get_all_assertion_ids():
     return _get_all_element_ids('assertions')
 
@@ -1435,10 +1439,14 @@ def bulk_search_variants_by_coordinates(sorted_queries, search_mode='any'):
     return dict(matches)
 
 
+@deprecation.deprecated(deprecated_in="1.1", removed_in="2.0",
+                        current_version=__version__)
 def get_all_variant_ids():
     return _get_all_element_ids('variants')
 
 
+@deprecation.deprecated(deprecated_in="1.1", removed_in="2.0",
+                        current_version=__version__)
 def _get_all_element_ids(element):
     url = 'https://civicdb.org/api/{}?count=100000'.format(element)
     resp = requests.get(url)
@@ -1474,6 +1482,8 @@ def get_gene_by_id(gene_id):
     return get_genes_by_ids([gene_id])[0]
 
 
+@deprecation.deprecated(deprecated_in="1.1", removed_in="2.0",
+                        current_version=__version__)
 def get_all_gene_ids():
     """
     Queries CIViC for a list of all gene IDs. Useful for passing to :func:`get_genes_by_ids` to
@@ -1506,6 +1516,8 @@ def get_all_genes(include_status=['accepted','submitted','rejected'], allow_cach
         return genes
 
 
+@deprecation.deprecated(deprecated_in="1.1", removed_in="2.0",
+                        current_version=__version__)
 def get_all_evidence_ids():
     return _get_all_element_ids('evidence_items')
 

--- a/civicpy/tests/test_civic.py
+++ b/civicpy/tests/test_civic.py
@@ -2,6 +2,7 @@ import pytest
 from civicpy import civic, TEST_CACHE_PATH
 from civicpy.civic import CoordinateQuery
 import logging
+import deprecation
 
 ELEMENTS = [
     'Assertion'
@@ -84,6 +85,7 @@ class TestEvidence(object):
         assert len(evidence) >= 3247
 
     #get_all_ids pulls from the live site so it will return more results than get_all_x
+    @deprecation.fail_if_not_removed
     def test_get_all_ids(self):
         evidence_ids = civic.get_all_evidence_ids()
         assert len(evidence_ids) >= len(civic.get_all_evidence())
@@ -108,6 +110,7 @@ class TestVariants(object):
         assert len(variants) >= 1333
 
     #get_all_ids pulls from the live site so it will return more results than get_all_x
+    @deprecation.fail_if_not_removed
     def test_get_all_ids(self):
         variant_ids = civic.get_all_variant_ids()
         assert len(variant_ids) >= len(civic.get_all_variants())
@@ -183,6 +186,7 @@ class TestGenes(object):
         assert len(genes) >= 322
 
     #get_all_ids pulls from the live site so it might return more results than get_all_x
+    @deprecation.fail_if_not_removed
     def test_get_all_ids(self):
         genes = civic.get_all_genes(include_status=['accepted'])
         gene_ids = civic.get_all_gene_ids()

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         'vcfpy',
         'pysam',
         'backports-datetime-fromisoformat',
+        'deprecation',
     ],
     extras_require={
         'test': [


### PR DESCRIPTION
Closes #90 