### PR TITLE
Throw fatal error when using `-` as the alt or ref in a coordinate query

### DIFF
--- a/civicpy/civic.py
+++ b/civicpy/civic.py
@@ -1217,10 +1217,14 @@ def search_variants_by_coordinates(coordinate_query, search_mode='any'):
         elif search_mode == 'exact':
             match_idx = (start == m_df.start) & (stop == m_df.stop)
             if coordinate_query.alt is not None and coordinate_query.alt != '*':
+                if coordinate_query.alt == '-':
+                    raise ValueError("Unexpected alt `-` in coordinate query. Did you mean `None`?")
                 match_idx = match_idx & (coordinate_query.alt == m_df.alt)
             elif coordinate_query.alt is None:
                 match_idx = match_idx & pd.isnull(m_df.alt)
             if (coordinate_query.ref is not None and coordinate_query.ref != '*'):
+                if coordinate_query.ref == '-':
+                    raise ValueError("Unexpected ref `-` in coordinate query. Did you mean `None`?")
                 match_idx = match_idx & (coordinate_query.ref == m_df.ref)
             elif coordinate_query.ref is None:
                 match_idx = match_idx & pd.isnull(m_df.ref)
@@ -1233,6 +1237,10 @@ def search_variants_by_coordinates(coordinate_query, search_mode='any'):
             if coordinate_query.alt or coordinate_query.ref:
                 if coordinate_query.alt == '*' or coordinate_query.ref == '*':
                     raise ValueError("Can't use wildcard when searching for non-GRCh37 coordinates")
+                if coordinate_query.alt == '-':
+                    raise ValueError("Unexpected alt `-` in coordinate query. Did you mean `None`?")
+                if coordinate_query.ref == '-':
+                    raise ValueError("Unexpected ref `-` in coordinate query. Did you mean `None`?")
                 hgvs = _construct_hgvs_for_coordinate_query(coordinate_query)
                 r = requests.get(url=_allele_registry_url(), params={'hgvs': hgvs})
                 data = r.json()
@@ -1397,6 +1405,10 @@ def bulk_search_variants_by_coordinates(sorted_queries, search_mode='any'):
             c_alt = c.alt
             q_ref = q.ref
             c_ref = c.ref
+            if q_alt == '-':
+                raise ValueError("Unexpected alt `-` in coordinate query. Did you mean `None`?")
+            if q_ref == '-':
+                raise ValueError("Unexpected ref `-` in coordinate query. Did you mean `None`?")
             if (not (q_alt != '*' and q_alt != c_alt)) and (not (q_ref != '*' and q_ref != c_ref)):
                 append_match(matches, q, c)
         elif search_mode == 'query_encompassing' and q_start <= c_start and q_stop >= c_stop:

--- a/civicpy/tests/test_civic.py
+++ b/civicpy/tests/test_civic.py
@@ -348,7 +348,30 @@ class TestCoordinateSearch(object):
             query = CoordinateQuery('7', 140753336, 140753336, 'T', 'A', 'GRCh38')
             search_results = civic.search_variants_by_coordinates(query, search_mode='any')
         assert "Only exact search mode is supported for non-GRCh37 coordinate queries" in str(context.value)
-
+        with pytest.raises(ValueError) as context:
+            query = CoordinateQuery('7', 140453136, 140453136, '-', 'A')
+            variants_single = civic.search_variants_by_coordinates(query, search_mode='exact')
+        assert "Unexpected alt `-` in coordinate query. Did you mean `None`?" in str(context.value)
+        with pytest.raises(ValueError) as context:
+            query = CoordinateQuery('7', 140453136, 140453136, 'T', '-')
+            variants_single = civic.search_variants_by_coordinates(query, search_mode='exact')
+        assert "Unexpected ref `-` in coordinate query. Did you mean `None`?" in str(context.value)
+        with pytest.raises(ValueError) as context:
+            query = CoordinateQuery('7', 140453136, 140453136, '-', 'A', 'GRCh38')
+            variants_single = civic.search_variants_by_coordinates(query, search_mode='exact')
+        assert "Unexpected alt `-` in coordinate query. Did you mean `None`?" in str(context.value)
+        with pytest.raises(ValueError) as context:
+            query = CoordinateQuery('7', 140453136, 140453136, 'T', '-', 'GRCh38')
+            variants_single = civic.search_variants_by_coordinates(query, search_mode='exact')
+        assert "Unexpected ref `-` in coordinate query. Did you mean `None`?" in str(context.value)
+        with pytest.raises(ValueError) as context:
+            query = CoordinateQuery('7', 140453136, 140453136, '-', 'A')
+            variants_bulk = civic.bulk_search_variants_by_coordinates([query], search_mode='exact')
+        assert "Unexpected alt `-` in coordinate query. Did you mean `None`?" in str(context.value)
+        with pytest.raises(ValueError) as context:
+            query = CoordinateQuery('7', 140453136, 140453136, 'T', '-')
+            variants_bulk = civic.bulk_search_variants_by_coordinates([query], search_mode='exact')
+        assert "Unexpected ref `-` in coordinate query. Did you mean `None`?" in str(context.value)
 
 
 class TestDrugs(object):


### PR DESCRIPTION
Closes #78 