### PR TITLE
A few variant coordinate search improvements

### DIFF
--- a/civicpy/civic.py
+++ b/civicpy/civic.py
@@ -1288,6 +1288,8 @@ def _construct_hgvs_for_coordinate_query(coordinate_query):
         chromosome = _refseq_sequence_b38(coordinate_query.chr)
     else:
         raise ValueError("unexpected reference build")
+    if chromosome is None:
+        return None
     base_hgvs = "{}:g.{}".format(chromosome, coordinate_query.start)
     variant_type = _variant_type(coordinate_query)
     if variant_type == "deletion":
@@ -1322,6 +1324,7 @@ def _variant_type(coordinate_query):
         return None
 
 def _refseq_sequence_b38(chromosome):
+    chromosome = chromosome.replace('chr', '')
     sequences = {
       '1' : 'NC_000001.11',
       '2' : 'NC_000002.12',
@@ -1348,6 +1351,8 @@ def _refseq_sequence_b38(chromosome):
       'X' : 'NC_000023.11',
       'Y' : 'NC_000024.10',
     }
+    if chromosome not in sequences:
+        return None
     return sequences[chromosome]
 
 # TODO: Refactor this method

--- a/civicpy/cli.py
+++ b/civicpy/cli.py
@@ -86,14 +86,13 @@ def annotate_vcf(input_vcf, output_vcf, reference, include_status):
                             end = start + len(ref) - 1
             query = CoordinateQuery(entry.CHROM, start, end, alt, ref, reference)
             variants = civic.search_variants_by_coordinates(query, search_mode='exact')
-            if len(variants) == 1:
-                csq = variants[0].csq(include_status)
-                if len(csq) > 0:
-                    entry.INFO['CIVIC'] = variants[0].csq(include_status)
-            elif len(variants) > 1:
-                print("More than one variant found for start {} stop {} ref {} alt {}. CIViC Variants IDs: {}".format(start, end, ref, alt, ",".join(list(map(lambda v: str(v.id), variants)))))
-            else:
-                print("No variant found for start {} stop {} ref {} alt {}".format(start, end, ref, alt))
+            if variants is not None:
+                if len(variants) == 1:
+                    csq = variants[0].csq(include_status)
+                    if len(csq) > 0:
+                        entry.INFO['CIVIC'] = variants[0].csq(include_status)
+                elif len(variants) > 1:
+                    print("More than one variant found for start {} stop {} ref {} alt {}. CIViC Variants IDs: {}".format(start, end, ref, alt, ",".join(list(map(lambda v: str(v.id), variants)))))
             writer.write_record(entry)
     writer.close()
     reader.close()


### PR DESCRIPTION
During the annotation of the TCGA I ran into a couple of bugs/problems:
- The queries to the allele registry would sometimes time out/hit the default retry limit, especially for larger files. This updates the number of retries to 5 and implements a backoff factor.
- Some chromosomes are not supported (e.g. M) and would throw an error in the `_refseq_sequence_b38` method
- GRCh38 uses the `chr` prefix, which we didn't handle.