### PR TITLE
Convert CIVICPY_CACHE_TIMEOUT_DAYS environment variable to int

### DIFF
--- a/civicpy/__init__.py
+++ b/civicpy/__init__.py
@@ -3,10 +3,16 @@ from pathlib import Path
 import os
 
 REMOTE_CACHE_URL = os.getenv('CIVICPY_REMOTE_CACHE_URL', False) or \
-                   "https://civicdb.org/downloads/nightly/nightly-civicpy_cache.pkl"
+    "https://civicdb.org/downloads/nightly/nightly-civicpy_cache.pkl"
 LOCAL_CACHE_PATH = os.getenv('CIVICPY_CACHE_FILE', False) or \
-                   str(Path.home() / '.civicpy' / 'cache.pkl')
+    str(Path.home() / '.civicpy' / 'cache.pkl')
 CACHE_TIMEOUT_DAYS = os.getenv('CIVICPY_CACHE_TIMEOUT_DAYS', False) or 7
+# We convert the CACHE_TIMEOUT_DAYS to int
+# if not possible we use the default value
+try:
+    CACHE_TIMEOUT_DAYS = int(CACHE_TIMEOUT_DAYS)
+except TypeError:
+    CACHE_TIMEOUT_DAYS = 7
 
 TEST_CACHE_PATH = str(Path(__file__).parent / 'data' / 'test_cache.pkl')
 


### PR DESCRIPTION
Because the value of an environment variable is treat as string it needs to be converted to int in case of CIVICPY_CACHE_TIMEOUT_DAYS. Otherwise the timedelta function will fail.