### PR TITLE
add github action to make pypi release when a release is made on github

### DIFF
--- a/.github/workflows/pypi_release.yaml
+++ b/.github/workflows/pypi_release.yaml
@@ -1,0 +1,24 @@
+name: Make PyPI release
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+    - name: Install dependencies
+      run: |
+        python3 -m pip install --upgrade pip
+        pip install setuptools wheel twine
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI }}
+      run: |
+        python3 setup.py sdist bdist_wheel
+        twine upload dist/*


### PR DESCRIPTION
We have this GitHub action in our other projects. I think it would be nice to have this automated pypi release for civicpy.

~~You will need to follow [these](https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#saving-credentials-on-github) instructions for saving the pypi api token in github. You will want to name this secret `PYPI`~~

^ Update: added the secret