### PR TITLE
fix: stay compatible with pandas >=2.0

### DIFF
--- a/civicpy/civic.py
+++ b/civicpy/civic.py
@@ -2162,7 +2162,7 @@ def search_variants_by_coordinates(coordinate_query, search_mode='any'):
         start_ct_idx = start_idx[:right_idx].index
         left_idx = stop_idx.searchsorted(start)
         stop_ct_idx = stop_idx[left_idx:].index
-        match_idx = chr_ct_idx & start_ct_idx & stop_ct_idx
+        match_idx = list(set(chr_ct_idx) & set(start_ct_idx) & set(stop_ct_idx))
         m_df = ct.loc[match_idx, ]
         if search_mode == 'any':
             var_digests = m_df.v_hash.to_list()


### PR DESCRIPTION
I had a problem running `search_variants_by_coordinates` from civicpy. After a bit of research I could figure out what the problem is:
Because of some implementation changes in pandas version >=2.0 a index series can no longer be intersected using the `&` operator, but a `set` can. I found the valuable hint to this problem here https://linuxhint.com/panda-series-intersection/. 

I hope you find this useful and you would merge this pull request.