### PR TITLE
feat: include molecular profile segment data in molecular profile response

### DIFF
--- a/civicpy/civic.py
+++ b/civicpy/civic.py
@@ -446,12 +446,20 @@ class MolecularProfile(CivicRecord):
         'evidence_items',
         'sources',
         'variants',
+        'parsed_name'
     })
 
     def __init__(self, **kwargs):
         self._evidence_items = []
         self._assertions = []
         self._variants = []
+
+        # Convert parsed name types from camel to snake case
+        parsed_name = kwargs.get('parsed_name')
+        if parsed_name:
+            for pn in parsed_name:
+                pn['type'] = ''.join(['_' + c.lower() if c.isupper() else c for c in pn['type']]).lstrip('_')
+
         super().__init__(**kwargs)
 
     @property
@@ -1408,6 +1416,21 @@ def _construct_get_molecular_profile_payload():
                   id
                 }
                 aliases: molecularProfileAliases
+                parsed_name: parsedName {
+                    type: __typename
+                    ... on MolecularProfileTextSegment {
+                        text
+                    }
+                    ... on Gene {
+                        id
+                        name
+                    }
+                    ... on Variant {
+                        id
+                        name
+                        deprecated
+                    }
+                }
                 sources {
                     id
                     name
@@ -1454,6 +1477,21 @@ def _construct_get_all_molecular_profiles_payload():
                   id
                 }
                 aliases: molecularProfileAliases
+                parsed_name: parsedName {
+                    type: __typename
+                    ... on MolecularProfileTextSegment {
+                        text
+                    }
+                    ... on Gene {
+                        id
+                        name
+                    }
+                    ... on Variant {
+                        id
+                        name
+                        deprecated
+                    }
+                }
                 sources {
                     id
                     name

--- a/civicpy/tests/test_civic.py
+++ b/civicpy/tests/test_civic.py
@@ -173,9 +173,30 @@ class TestMolecularProfiles(object):
         assert len(mps) >= 1333
 
     def test_get_by_id(self):
-        mp = civic.get_molecular_profile_by_id(6353)
+        # Complex MP
+        mp = civic.get_molecular_profile_by_id(4432)
         assert mp.type == 'molecular_profile'
-        assert mp.id == 6353
+        mp_parsed_name = mp.parsed_name
+        assert len(mp_parsed_name) == 5
+        egfr_gene = mp_parsed_name[0]
+        assert egfr_gene.type == "gene"
+        assert egfr_gene.id == 19
+        assert egfr_gene.name == "EGFR"
+        variant0 = mp_parsed_name[1]
+        assert variant0.type == "variant"
+        assert variant0.id == 33
+        assert variant0.name == "L858R"
+        assert variant0.deprecated is False
+        text_segment = mp_parsed_name[2]
+        assert text_segment.type == "molecular_profile_text_segment"
+        assert text_segment.text == "OR"
+        assert mp_parsed_name[3] == egfr_gene
+        variant1 = mp_parsed_name[4]
+        assert variant1.type == "variant"
+        assert variant1.id == 133
+        assert variant1.name == "Exon 19 Deletion"
+        assert variant1.deprecated is False
+
 
 class TestVariantGroups(object):
 


### PR DESCRIPTION
close #143 . This is needed for [this](https://github.com/griffithlab/civic-meeting/issues/61) hackathon issue.

@susannasiebert I can't remember how the `test_cache.pkl` is populated for the tests. I ran `civicpy update --hard` and used this as my cache. The molecular profile tests had `6353` as an ID. I tried using the graphiql api and looked at https://civicdb.org/molecular-profiles/6353/summary , but the molecular profile does not exist. 3 of the tests are failing (on both my cache with changes from my branch and the cache from the `master` branch). Depending on how the `test_cache.pkl` is populated, I can update in a separate issue. 