### PR TITLE
Add --version support

### DIFF
--- a/civicpy/cli.py
+++ b/civicpy/cli.py
@@ -5,12 +5,14 @@ from civicpy.civic import CoordinateQuery
 import vcfpy
 import binascii
 from collections import OrderedDict
+from civicpy.__version__ import __version__
 
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 
 
 @click.group(context_settings=CONTEXT_SETTINGS)
+@click.version_option(__version__)
 def cli():
     pass
 


### PR DESCRIPTION
I was trying to see if the version of civicpy installed on the new civic VM was correct, and realized there's no `--version` support.  This adds that:

```
❯ ./venv/bin/civicpy --help
Usage: civicpy [OPTIONS] COMMAND [ARGS]...

Options:
  --version   Show the version and exit.
  -h, --help  Show this message and exit.

Commands:
  annotate-vcf  Annotate a VCF with information from CIViC
  create-vcf    Create a VCF file of CIViC variants
  update        Updates CIViC content from server and stores to local...

```


```
❯ ./venv/bin/civicpy --version
civicpy, version 4.0.1
```

Unrelated, but notable, I was not able to get `backports-datetime-fromisoformat` to install locally no matter what I tried. (I did only spend like 10 mins looking into it though).

Based on the README its "A backport of Python 3.11's datetime.fromisoformat methods to earlier versions of Python 3. Tested against Python 3.6, 3.7, 3.8, 3.9, 3.10 and 3.11."

I'm guessing it s too early to drop 3.10 support since it's not technically EOL yet, but once it is, maybe we should drop support for it and get rid of that dependency?


