### PR TITLE
feat: Add strand to FusionVariant output

### DIFF
--- a/civicpy/civic.py
+++ b/civicpy/civic.py
@@ -401,6 +401,7 @@ class CivicRecord:
 
     _SIMPLE_FIELDS = {'id', 'type'}
     _COMPLEX_FIELDS = set()
+    _NULLABLE_COMPLEX_FIELDS = set()
     _OPTIONAL_FIELDS = set()
 
     def __init__(self, partial=False, **kwargs):
@@ -456,7 +457,10 @@ class CivicRecord:
                 t = v.get('type', field)
                 v['type'] = CIVIC_TO_PYCLASS.get(t, t)
                 if v.keys() == {'type'}:
-                    self.__setattr__(field, {})
+                    if field in self._NULLABLE_COMPLEX_FIELDS:
+                        self.__setattr__(field, None)
+                    else:
+                        self.__setattr__(field, {})
                 else:
                     self.__setattr__(field, cls(partial=True, **v))
 
@@ -981,6 +985,14 @@ class FusionVariant(Variant):
         'vicc_compliant_name',
     })
     _COMPLEX_FIELDS = Variant._COMPLEX_FIELDS.union({
+        'five_prime_coordinates',
+        'three_prime_coordinates',
+        'five_prime_start_exon_coordinates',
+        'five_prime_end_exon_coordinates',
+        'three_prime_start_exon_coordinates',
+        'three_prime_end_exon_coordinates',
+    })
+    _NULLABLE_COMPLEX_FIELDS = Variant._NULLABLE_COMPLEX_FIELDS.union({
         'five_prime_coordinates',
         'three_prime_coordinates',
         'five_prime_start_exon_coordinates',

--- a/civicpy/civic.py
+++ b/civicpy/civic.py
@@ -46,8 +46,8 @@ CIVIC_TO_PYCLASS = {
 }
 
 
-_CoordinateQuery = namedtuple('CoordinateQuery', ['chr', 'start', 'stop', 'strand','alt', 'ref', 'build', 'key'])
-_CoordinateQuery.__new__.__defaults__ = (None, None, None, "GRCh37", None)
+_CoordinateQuery = namedtuple('CoordinateQuery', ['chr', 'start', 'stop', 'alt', 'ref', 'build', 'key'])
+_CoordinateQuery.__new__.__defaults__ = (None, None, "GRCh37", None)
 
 
 class CoordinateQuery(_CoordinateQuery):  # Wrapping for documentation

--- a/civicpy/civic.py
+++ b/civicpy/civic.py
@@ -46,8 +46,8 @@ CIVIC_TO_PYCLASS = {
 }
 
 
-_CoordinateQuery = namedtuple('CoordinateQuery', ['chr', 'start', 'stop', 'alt', 'ref', 'build', 'key'])
-_CoordinateQuery.__new__.__defaults__ = (None, None, "GRCh37", None)
+_CoordinateQuery = namedtuple('CoordinateQuery', ['chr', 'start', 'stop', 'strand','alt', 'ref', 'build', 'key'])
+_CoordinateQuery.__new__.__defaults__ = (None, None, None, "GRCh37", None)
 
 
 class CoordinateQuery(_CoordinateQuery):  # Wrapping for documentation
@@ -978,7 +978,9 @@ class FusionVariant(Variant):
     })
     _COMPLEX_FIELDS = Variant._COMPLEX_FIELDS.union({
         'five_prime_coordinates',
+        'five_prime_strand',
         'three_prime_coordinates',
+        'three_prime_strand'
     })
 
     @property
@@ -2432,7 +2434,7 @@ def get_all_fusion_variants(include_status=['accepted', 'submitted', 'rejected']
     :param bool allow_cached: Indicates whether or not object retrieval from CACHE is allowed. If **False** it will query the CIViC database directly.
     :returns: A list of :class:`Variant` objects of **subtype** **fusion_variant**.
     """
-    variants = get_all_variants(include_status=include_status, allow_cached=True)
+    variants = get_all_variants(include_status=include_status, allow_cached=allow_cached)
     return [v for v in variants if v.subtype == 'fusion_variant']
 
 

--- a/civicpy/civic.py
+++ b/civicpy/civic.py
@@ -977,10 +977,10 @@ class FusionVariant(Variant):
         'vicc_compliant_name',
     })
     _COMPLEX_FIELDS = Variant._COMPLEX_FIELDS.union({
-        'five_prime_coordinates',
-        'five_prime_strand',
-        'three_prime_coordinates',
-        'three_prime_strand'
+        'five_prime_exon_start_coordinates',
+        'five_prime_exon_end_coordinates',
+        'three_prime_exon_start_coordinates',
+        'three_prime_exon_end_coordinates',
     })
 
     @property

--- a/civicpy/civic.py
+++ b/civicpy/civic.py
@@ -1951,6 +1951,14 @@ def _postprocess_response_element(e, element):
         elif e['__typename'] == 'FactorVariant':
             e['subtype'] = 'factor_variant'
         elif e['__typename'] == 'FusionVariant':
+            if e['five_prime_start_exon_coordinates'] and e['five_prime_start_exon_coordinates']['exon_offset'] is None:
+                e['five_prime_start_exon_coordinates']['exon_offset'] = 0
+            if e['five_prime_end_exon_coordinates'] and e['five_prime_end_exon_coordinates']['exon_offset'] is None:
+                e['five_prime_end_exon_coordinates']['exon_offset'] = 0
+            if e['three_prime_start_exon_coordinates'] and e['three_prime_start_exon_coordinates']['exon_offset'] is None:
+                e['three_prime_start_exon_coordinates']['exon_offset'] = 0
+            if e['three_prime_end_exon_coordinates'] and e['three_prime_end_exon_coordinates']['exon_offset'] is None:
+                e['three_prime_end_exon_coordinates']['exon_offset'] = 0
             e['subtype'] = 'fusion_variant'
         else:
             raise Exception("Variant type {} not supported yet".format(e['__typename']))

--- a/civicpy/graphql_payloads.py
+++ b/civicpy/graphql_payloads.py
@@ -298,6 +298,9 @@ def _construct_get_all_variants_payload():
                             reference_bases: referenceBases
                             variant_bases: variantBases
                         }
+                        five_prime_strand: fivePrimeEndExonCoordinates {
+                            strand
+                        }
                         three_prime_coordinates: threePrimeCoordinates {
                             reference_build: referenceBuild
                             ensembl_version: ensemblVersion
@@ -307,6 +310,9 @@ def _construct_get_all_variants_payload():
                             stop
                             reference_bases: referenceBases
                             variant_bases: variantBases
+                        }
+                        three_prime_strand: threePrimeEndExonCoordinates {
+                            strand
                         }
                     }
                     feature {

--- a/civicpy/graphql_payloads.py
+++ b/civicpy/graphql_payloads.py
@@ -288,30 +288,40 @@ def _construct_get_all_variants_payload():
                     }
                     ... on FusionVariant {
                         vicc_compliant_name: viccCompliantName
-                        five_prime_coordinates: fivePrimeCoordinates {
+                        five_prime_exon_start_coordinates: fivePrimeStartExonCoordinates {
                             reference_build: referenceBuild
                             ensembl_version: ensemblVersion
                             chromosome
                             representative_transcript: representativeTranscript
                             start
                             stop
-                            reference_bases: referenceBases
-                            variant_bases: variantBases
-                        }
-                        five_prime_strand: fivePrimeEndExonCoordinates {
                             strand
                         }
-                        three_prime_coordinates: threePrimeCoordinates {
+                        five_prime_exon_end_coordinates: fivePrimeEndExonCoordinates {
                             reference_build: referenceBuild
                             ensembl_version: ensemblVersion
                             chromosome
                             representative_transcript: representativeTranscript
                             start
                             stop
-                            reference_bases: referenceBases
-                            variant_bases: variantBases
+                            strand
                         }
-                        three_prime_strand: threePrimeEndExonCoordinates {
+                        three_prime_exon_start_coordinates: threePrimeStartExonCoordinates {
+                            reference_build: referenceBuild
+                            ensembl_version: ensemblVersion
+                            chromosome
+                            representative_transcript: representativeTranscript
+                            start
+                            stop
+                            strand
+                        }
+                        three_prime_exon_end_coordinates: threePrimeEndExonCoordinates {
+                            reference_build: referenceBuild
+                            ensembl_version: ensemblVersion
+                            chromosome
+                            representative_transcript: representativeTranscript
+                            start
+                            stop
                             strand
                         }
                     }

--- a/civicpy/graphql_payloads.py
+++ b/civicpy/graphql_payloads.py
@@ -230,6 +230,81 @@ def _construct_get_variant_payload():
                         variant_bases: variantBases
                     }
                 }
+                ... on FusionVariant {
+                    vicc_compliant_name: viccCompliantName
+                    five_prime_coordinates: fivePrimeCoordinates {
+                        reference_build: referenceBuild
+                        ensembl_version: ensemblVersion
+                        chromosome
+                        representative_transcript: representativeTranscript
+                        start
+                        stop
+                        reference_bases: referenceBases
+                        variant_bases: variantBases
+                    }
+                    three_prime_coordinates: threePrimeCoordinates {
+                        reference_build: referenceBuild
+                        ensembl_version: ensemblVersion
+                        chromosome
+                        representative_transcript: representativeTranscript
+                        start
+                        stop
+                        reference_bases: referenceBases
+                        variant_bases: variantBases
+                    }
+                    five_prime_exon_start_coordinates: fivePrimeStartExonCoordinates {
+                        chromosome
+                        ensembl_id: ensemblId
+                        ensembl_version: ensemblVersion
+                        exon
+                        exon_offset: exonOffset
+                        exon_offset_direction: exonOffsetDirection
+                        reference_build: referenceBuild
+                        representative_transcript: representativeTranscript
+                        start
+                        stop
+                        strand
+                    }
+                    five_prime_exon_end_coordinates: fivePrimeEndExonCoordinates {
+                        chromosome
+                        ensembl_id: ensemblId
+                        ensembl_version: ensemblVersion
+                        exon
+                        exon_offset: exonOffset
+                        exon_offset_direction: exonOffsetDirection
+                        reference_build: referenceBuild
+                        representative_transcript: representativeTranscript
+                        start
+                        stop
+                        strand
+                    }
+                    three_prime_exon_start_coordinates: threePrimeStartExonCoordinates {
+                        chromosome
+                        ensembl_id: ensemblId
+                        ensembl_version: ensemblVersion
+                        exon
+                        exon_offset: exonOffset
+                        exon_offset_direction: exonOffsetDirection
+                        reference_build: referenceBuild
+                        representative_transcript: representativeTranscript
+                        start
+                        stop
+                        strand
+                    }
+                    three_prime_exon_end_coordinates: threePrimeEndExonCoordinates {
+                        chromosome
+                        ensembl_id: ensemblId
+                        ensembl_version: ensemblVersion
+                        exon
+                        exon_offset: exonOffset
+                        exon_offset_direction: exonOffsetDirection
+                        reference_build: referenceBuild
+                        representative_transcript: representativeTranscript
+                        start
+                        stop
+                        strand
+                    }
+                }
                 ... on FactorVariant {
                     ncit_id: ncitId
                 }
@@ -288,37 +363,73 @@ def _construct_get_all_variants_payload():
                     }
                     ... on FusionVariant {
                         vicc_compliant_name: viccCompliantName
-                        five_prime_exon_start_coordinates: fivePrimeStartExonCoordinates {
+                        five_prime_coordinates: fivePrimeCoordinates {
                             reference_build: referenceBuild
                             ensembl_version: ensemblVersion
                             chromosome
                             representative_transcript: representativeTranscript
                             start
                             stop
-                            strand
+                            reference_bases: referenceBases
+                            variant_bases: variantBases
                         }
-                        five_prime_exon_end_coordinates: fivePrimeEndExonCoordinates {
+                        three_prime_coordinates: threePrimeCoordinates {
                             reference_build: referenceBuild
                             ensembl_version: ensemblVersion
                             chromosome
                             representative_transcript: representativeTranscript
                             start
                             stop
-                            strand
+                            reference_bases: referenceBases
+                            variant_bases: variantBases
                         }
-                        three_prime_exon_start_coordinates: threePrimeStartExonCoordinates {
-                            reference_build: referenceBuild
-                            ensembl_version: ensemblVersion
+                        five_prime_start_exon_coordinates: fivePrimeStartExonCoordinates {
                             chromosome
+                            ensembl_id: ensemblId
+                            ensembl_version: ensemblVersion
+                            exon
+                            exon_offset: exonOffset
+                            exon_offset_direction: exonOffsetDirection
+                            reference_build: referenceBuild
                             representative_transcript: representativeTranscript
                             start
                             stop
                             strand
                         }
-                        three_prime_exon_end_coordinates: threePrimeEndExonCoordinates {
-                            reference_build: referenceBuild
-                            ensembl_version: ensemblVersion
+                        five_prime_end_exon_coordinates: fivePrimeEndExonCoordinates {
                             chromosome
+                            ensembl_id: ensemblId
+                            ensembl_version: ensemblVersion
+                            exon
+                            exon_offset: exonOffset
+                            exon_offset_direction: exonOffsetDirection
+                            reference_build: referenceBuild
+                            representative_transcript: representativeTranscript
+                            start
+                            stop
+                            strand
+                        }
+                        three_prime_start_exon_coordinates: threePrimeStartExonCoordinates {
+                            chromosome
+                            ensembl_id: ensemblId
+                            ensembl_version: ensemblVersion
+                            exon
+                            exon_offset: exonOffset
+                            exon_offset_direction: exonOffsetDirection
+                            reference_build: referenceBuild
+                            representative_transcript: representativeTranscript
+                            start
+                            stop
+                            strand
+                        }
+                        three_prime_end_exon_coordinates: threePrimeEndExonCoordinates {
+                            chromosome
+                            ensembl_id: ensemblId
+                            ensembl_version: ensemblVersion
+                            exon
+                            exon_offset: exonOffset
+                            exon_offset_direction: exonOffsetDirection
+                            reference_build: referenceBuild
                             representative_transcript: representativeTranscript
                             start
                             stop

--- a/civicpy/graphql_payloads.py
+++ b/civicpy/graphql_payloads.py
@@ -252,7 +252,7 @@ def _construct_get_variant_payload():
                         reference_bases: referenceBases
                         variant_bases: variantBases
                     }
-                    five_prime_exon_start_coordinates: fivePrimeStartExonCoordinates {
+                    five_prime_start_exon_coordinates: fivePrimeStartExonCoordinates {
                         chromosome
                         ensembl_id: ensemblId
                         ensembl_version: ensemblVersion
@@ -265,7 +265,7 @@ def _construct_get_variant_payload():
                         stop
                         strand
                     }
-                    five_prime_exon_end_coordinates: fivePrimeEndExonCoordinates {
+                    five_prime_end_exon_coordinates: fivePrimeEndExonCoordinates {
                         chromosome
                         ensembl_id: ensemblId
                         ensembl_version: ensemblVersion
@@ -278,7 +278,7 @@ def _construct_get_variant_payload():
                         stop
                         strand
                     }
-                    three_prime_exon_start_coordinates: threePrimeStartExonCoordinates {
+                    three_prime_start_exon_coordinates: threePrimeStartExonCoordinates {
                         chromosome
                         ensembl_id: ensemblId
                         ensembl_version: ensemblVersion
@@ -291,7 +291,7 @@ def _construct_get_variant_payload():
                         stop
                         strand
                     }
-                    three_prime_exon_end_coordinates: threePrimeEndExonCoordinates {
+                    three_prime_end_exon_coordinates: threePrimeEndExonCoordinates {
                         chromosome
                         ensembl_id: ensemblId
                         ensembl_version: ensemblVersion

--- a/civicpy/tests/test_civic.py
+++ b/civicpy/tests/test_civic.py
@@ -206,8 +206,20 @@ class TestFusionVariants(object):
     def test_attributes(self):
         variant = civic.get_variant_by_id(1)
         assert variant.vicc_compliant_name == 'BCR(entrez:613)::ABL1(entrez:25)'
-        assert variant.five_prime_coordinates.reference_build == 'GRCH37'
-        assert variant.three_prime_coordinates.reference_build == 'GRCH37'
+        assert variant.five_prime_start_exon_coordinates.chromosome == "22"
+        assert variant.five_prime_start_exon_coordinates.start == 23522397
+        assert variant.five_prime_start_exon_coordinates.stop == 23524426
+        assert variant.five_prime_end_exon_coordinates.chromosome == "22"
+        assert variant.five_prime_end_exon_coordinates.start == 23632526
+        assert variant.five_prime_end_exon_coordinates.stop == 23632600
+        assert variant.three_prime_start_exon_coordinates.chromosome == "9"
+        assert variant.three_prime_start_exon_coordinates.start == 133729451
+        assert variant.three_prime_start_exon_coordinates.stop == 133729624
+        assert variant.three_prime_end_exon_coordinates.chromosome == "9"
+        assert variant.three_prime_end_exon_coordinates.start == 133759356
+        assert variant.three_prime_end_exon_coordinates.stop == 133763062
+        assert variant.five_prime_end_exon_coordinates.strand == "POSITIVE"
+        assert variant.three_prime_end_exon_coordinates.strand == "POSITIVE"
 
     def test_properties(self):
         variant = civic.get_variant_by_id(1)

--- a/civicpy/tests/test_civic.py
+++ b/civicpy/tests/test_civic.py
@@ -207,27 +207,53 @@ class TestFusionVariants(object):
         variant = civic.get_variant_by_id(1)
         assert variant.vicc_compliant_name == 'BCR(entrez:613)::ABL1(entrez:25)'
         assert variant.five_prime_start_exon_coordinates.chromosome == "22"
+        assert variant.five_prime_start_exon_coordinates.reference_build == "GRCH37"
+        assert variant.five_prime_start_exon_coordinates.ensembl_id == "ENSE00001897802"
+        assert variant.five_prime_start_exon_coordinates.ensembl_version == 75
+        assert variant.five_prime_start_exon_coordinates.representative_transcript == "ENST00000305877.8"
+        assert variant.five_prime_start_exon_coordinates.strand == "POSITIVE"
         assert variant.five_prime_start_exon_coordinates.exon == 1
-        assert variant.five_prime_start_exon_coordinates.exon_offset == 0
+        assert variant.five_prime_start_exon_coordinates.exon_offset is None
+        assert variant.five_prime_start_exon_coordinates.exon_offset_direction is None
         assert variant.five_prime_start_exon_coordinates.start == 23522397
         assert variant.five_prime_start_exon_coordinates.stop == 23524426
+
         assert variant.five_prime_end_exon_coordinates.chromosome == "22"
+        assert variant.five_prime_end_exon_coordinates.reference_build == "GRCH37"
+        assert variant.five_prime_end_exon_coordinates.ensembl_id == "ENSE00001781765"
+        assert variant.five_prime_end_exon_coordinates.ensembl_version == 75
+        assert variant.five_prime_end_exon_coordinates.representative_transcript == "ENST00000305877.8"
+        assert variant.five_prime_end_exon_coordinates.strand == "POSITIVE"
         assert variant.five_prime_end_exon_coordinates.exon == 14
-        assert variant.five_prime_end_exon_coordinates.exon_offset == 0
+        assert variant.five_prime_end_exon_coordinates.exon_offset is None
+        assert variant.five_prime_end_exon_coordinates.exon_offset_direction is None
         assert variant.five_prime_end_exon_coordinates.start == 23632526
         assert variant.five_prime_end_exon_coordinates.stop == 23632600
+
         assert variant.three_prime_start_exon_coordinates.chromosome == "9"
+        assert variant.three_prime_start_exon_coordinates.reference_build == "GRCH37"
+        assert variant.three_prime_start_exon_coordinates.ensembl_id == "ENSE00000984287"
+        assert variant.three_prime_start_exon_coordinates.ensembl_version == 75
+        assert variant.three_prime_start_exon_coordinates.representative_transcript == "ENST00000318560.5"
+        assert variant.three_prime_start_exon_coordinates.strand == "POSITIVE"
         assert variant.three_prime_start_exon_coordinates.exon == 2
-        assert variant.three_prime_start_exon_coordinates.exon_offset == 0
+        assert variant.three_prime_start_exon_coordinates.exon_offset is None
+        assert variant.three_prime_start_exon_coordinates.exon_offset_direction is None
         assert variant.three_prime_start_exon_coordinates.start == 133729451
         assert variant.three_prime_start_exon_coordinates.stop == 133729624
+
         assert variant.three_prime_end_exon_coordinates.chromosome == "9"
+        assert variant.three_prime_end_exon_coordinates.reference_build == "GRCH37"
+        assert variant.three_prime_end_exon_coordinates.ensembl_id == "ENSE00001457584"
+        assert variant.three_prime_end_exon_coordinates.ensembl_version == 75
+        assert variant.three_prime_end_exon_coordinates.representative_transcript == "ENST00000318560.5"
+        assert variant.three_prime_end_exon_coordinates.strand == "POSITIVE"
         assert variant.three_prime_end_exon_coordinates.exon == 11
-        assert variant.three_prime_start_exon_coordinates.exon_offset == 0
+        assert variant.three_prime_end_exon_coordinates.exon_offset is None
+        assert variant.three_prime_end_exon_coordinates.exon_offset_direction is None
         assert variant.three_prime_end_exon_coordinates.start == 133759356
         assert variant.three_prime_end_exon_coordinates.stop == 133763062
-        assert variant.five_prime_end_exon_coordinates.strand == "POSITIVE"
-        assert variant.three_prime_end_exon_coordinates.strand == "POSITIVE"
+ 
 
     def test_properties(self):
         variant = civic.get_variant_by_id(1)

--- a/civicpy/tests/test_civic.py
+++ b/civicpy/tests/test_civic.py
@@ -213,7 +213,7 @@ class TestFusionVariants(object):
         assert variant.five_prime_start_exon_coordinates.representative_transcript == "ENST00000305877.8"
         assert variant.five_prime_start_exon_coordinates.strand == "POSITIVE"
         assert variant.five_prime_start_exon_coordinates.exon == 1
-        assert variant.five_prime_start_exon_coordinates.exon_offset is None
+        assert variant.five_prime_start_exon_coordinates.exon_offset==0
         assert variant.five_prime_start_exon_coordinates.exon_offset_direction is None
         assert variant.five_prime_start_exon_coordinates.start == 23522397
         assert variant.five_prime_start_exon_coordinates.stop == 23524426
@@ -225,7 +225,7 @@ class TestFusionVariants(object):
         assert variant.five_prime_end_exon_coordinates.representative_transcript == "ENST00000305877.8"
         assert variant.five_prime_end_exon_coordinates.strand == "POSITIVE"
         assert variant.five_prime_end_exon_coordinates.exon == 14
-        assert variant.five_prime_end_exon_coordinates.exon_offset is None
+        assert variant.five_prime_end_exon_coordinates.exon_offset==0
         assert variant.five_prime_end_exon_coordinates.exon_offset_direction is None
         assert variant.five_prime_end_exon_coordinates.start == 23632526
         assert variant.five_prime_end_exon_coordinates.stop == 23632600
@@ -237,7 +237,7 @@ class TestFusionVariants(object):
         assert variant.three_prime_start_exon_coordinates.representative_transcript == "ENST00000318560.5"
         assert variant.three_prime_start_exon_coordinates.strand == "POSITIVE"
         assert variant.three_prime_start_exon_coordinates.exon == 2
-        assert variant.three_prime_start_exon_coordinates.exon_offset is None
+        assert variant.three_prime_start_exon_coordinates.exon_offset==0
         assert variant.three_prime_start_exon_coordinates.exon_offset_direction is None
         assert variant.three_prime_start_exon_coordinates.start == 133729451
         assert variant.three_prime_start_exon_coordinates.stop == 133729624
@@ -249,11 +249,16 @@ class TestFusionVariants(object):
         assert variant.three_prime_end_exon_coordinates.representative_transcript == "ENST00000318560.5"
         assert variant.three_prime_end_exon_coordinates.strand == "POSITIVE"
         assert variant.three_prime_end_exon_coordinates.exon == 11
-        assert variant.three_prime_end_exon_coordinates.exon_offset is None
+        assert variant.three_prime_end_exon_coordinates.exon_offset==0
         assert variant.three_prime_end_exon_coordinates.exon_offset_direction is None
         assert variant.three_prime_end_exon_coordinates.start == 133759356
         assert variant.three_prime_end_exon_coordinates.stop == 133763062
- 
+
+    def test_nullable_fields(self):
+        variant = civic.get_variant_by_id(739)
+        assert variant.three_prime_coordinates is None
+        assert variant.three_prime_start_exon_coordinates is None
+        assert variant.three_prime_end_exon_coordinates is None
 
     def test_properties(self):
         variant = civic.get_variant_by_id(1)

--- a/civicpy/tests/test_civic.py
+++ b/civicpy/tests/test_civic.py
@@ -207,15 +207,23 @@ class TestFusionVariants(object):
         variant = civic.get_variant_by_id(1)
         assert variant.vicc_compliant_name == 'BCR(entrez:613)::ABL1(entrez:25)'
         assert variant.five_prime_start_exon_coordinates.chromosome == "22"
+        assert variant.five_prime_start_exon_coordinates.exon == 1
+        assert variant.five_prime_start_exon_coordinates.exon_offset == 0
         assert variant.five_prime_start_exon_coordinates.start == 23522397
         assert variant.five_prime_start_exon_coordinates.stop == 23524426
         assert variant.five_prime_end_exon_coordinates.chromosome == "22"
+        assert variant.five_prime_end_exon_coordinates.exon == 14
+        assert variant.five_prime_end_exon_coordinates.exon_offset == 0
         assert variant.five_prime_end_exon_coordinates.start == 23632526
         assert variant.five_prime_end_exon_coordinates.stop == 23632600
         assert variant.three_prime_start_exon_coordinates.chromosome == "9"
+        assert variant.three_prime_start_exon_coordinates.exon == 2
+        assert variant.three_prime_start_exon_coordinates.exon_offset == 0
         assert variant.three_prime_start_exon_coordinates.start == 133729451
         assert variant.three_prime_start_exon_coordinates.stop == 133729624
         assert variant.three_prime_end_exon_coordinates.chromosome == "9"
+        assert variant.three_prime_end_exon_coordinates.exon == 11
+        assert variant.three_prime_start_exon_coordinates.exon_offset == 0
         assert variant.three_prime_end_exon_coordinates.start == 133759356
         assert variant.three_prime_end_exon_coordinates.stop == 133763062
         assert variant.five_prime_end_exon_coordinates.strand == "POSITIVE"

--- a/civicpy/tests/test_civic.py
+++ b/civicpy/tests/test_civic.py
@@ -520,9 +520,9 @@ class TestDiseases(object):
 
     def test_properties(self):
         breast_cancer = civic.get_disease_by_id(22)
-        assert len(breast_cancer.evidence) == 280
+        assert len(breast_cancer.evidence) >= 280
         assert breast_cancer.evidence == breast_cancer.evidence_items
-        assert len(breast_cancer.assertions) == 2
+        assert len(breast_cancer.assertions) >= 2
 
 
 class TestTherapies(object):
@@ -558,9 +558,9 @@ class TestTherapies(object):
 
     def test_properties(self):
         trametinib = civic.get_therapy_by_id(19)
-        assert len(trametinib.evidence) == 138
+        assert len(trametinib.evidence) >= 138
         assert trametinib.evidence == trametinib.evidence_items
-        assert len(trametinib.assertions) == 3
+        assert len(trametinib.assertions) >= 3
 
 
 class TestPhenotypes(object):
@@ -584,9 +584,9 @@ class TestPhenotypes(object):
 
     def test_properties(self):
         pediatric_onset = civic.get_phenotype_by_id(15320)
-        assert len(pediatric_onset.evidence) == 140
+        assert len(pediatric_onset.evidence) >= 140
         assert pediatric_onset.evidence == pediatric_onset.evidence_items
-        assert len(pediatric_onset.assertions) == 27
+        assert len(pediatric_onset.assertions) >= 27
 
 
 class TestCoordinateSearch(object):


### PR DESCRIPTION
closes #156 

This PR adds two new features to the `FusionVariant` output: `five_prime_strand` and `three_prime_strand`
