### PR TITLE
fix: return phenotypes for evidence items

### DIFF
--- a/civicpy/civic.py
+++ b/civicpy/civic.py
@@ -1898,7 +1898,6 @@ def _postprocess_response_element(e, element):
         e['phenotype_ids'] = [p['id'] for p in e['phenotypes']]
         e['status'] = e['status'].lower()
         del e['therapies']
-        del e['phenotypes']
     elif element == 'factor':
         e['source_ids'] = [v['id'] for v in e['sources']]
         del e['sources']

--- a/civicpy/tests/test_civic.py
+++ b/civicpy/tests/test_civic.py
@@ -112,6 +112,12 @@ class TestEvidence(object):
         assert len(evidence.therapies) == 1
         assert len(evidence.phenotypes) == 0
 
+        evidence = civic.get_evidence_by_id(7365)
+        expected_phenotype_ids = {15320, 16642}
+        assert set(evidence.phenotype_ids) == expected_phenotype_ids
+        assert len(evidence.phenotypes) == 2
+        for p in evidence.phenotypes:
+            assert p.id in expected_phenotype_ids
 
 class TestVariants(object):
 


### PR DESCRIPTION
close #174

I'm not sure if this was the correct fix... I reverted the line that was made in fd2207921734aa789676b252e1bae5e695920331 . I basically followed what was done for assertions https://github.com/griffithlab/civicpy/blob/65e98f4df164265a3cad39467735f90f83a038eb/civicpy/civic.py#L1879-L1888