### PR TITLE
bump civicpy to version 5.1.0

### DIFF
--- a/civicpy/__version__.py
+++ b/civicpy/__version__.py
@@ -1,15 +1,15 @@
-__title__ = 'civicpy'
-__description__ = 'CIViC variant knowledgebase analysis toolkit.'
-__url__ = 'http://civicpy.org'
-__major__ = '5'
-__minor__ = '0'
-__patch__ = '0'
-__meta_label__ = ''
+__title__ = "civicpy"
+__description__ = "CIViC variant knowledgebase analysis toolkit."
+__url__ = "http://civicpy.org"
+__major__ = "5"
+__minor__ = "1"
+__patch__ = "0"
+__meta_label__ = ""
 __short_version__ = "{}.{}".format(__major__, __minor__)
 __version__ = "{}.{}".format(__short_version__, __patch__)
 if __meta_label__:
     __version__ += "-{}".format(__meta_label__)
-__authors__ = ['Alex H. Wagner', 'Susanna Kiwala', 'Adam Coffman']
-__author_email__ = 'help@civicpy.org'
-__license__ = 'MIT'
-__copyright__ = 'Copyright 2018-2024 The Griffith Lab'
+__authors__ = ["Alex H. Wagner", "Susanna Kiwala", "Adam Coffman"]
+__author_email__ = "help@civicpy.org"
+__license__ = "MIT"
+__copyright__ = "Copyright 2018-2024 The Griffith Lab"

--- a/environment.yml
+++ b/environment.yml
@@ -8,4 +8,4 @@ dependencies:
   - sphinxjp.themes.basicstrap
   - Cython
     #  - pandas==2.0.3
-  - civicpy==5.0.0
+  - civicpy==5.1.0


### PR DESCRIPTION
The endorsements rename is live on prod so I believe this can now be published as a new release. 