### PR TITLE
feat: add reportedIn to hasEvidenceLines

### DIFF
--- a/civicpy/exports/civic_gks_record.py
+++ b/civicpy/exports/civic_gks_record.py
@@ -2,6 +2,7 @@
 
 from abc import ABC
 from enum import Enum
+import logging
 import re
 from types import MappingProxyType
 
@@ -58,6 +59,7 @@ from civicpy.civic import (
     MolecularProfile,
 )
 
+_logger = logging.getLogger(__name__)
 
 PUBMED_URL = "https://pubmed.ncbi.nlm.nih.gov"
 
@@ -925,16 +927,34 @@ class _CivicGksAssertionRecord(_CivicGksEvidenceAssertionMixin, ABC):
             if assertion.assertion_direction == "SUPPORTS"
             else Direction.DISPUTES
         )
-        evidence_items = [
-            CivicGksEvidence(evidence_item)
-            for evidence_item in assertion.evidence_items
-        ]
+
+        evidence_items: list[CivicGksEvidence] = []
+        reported_in: list[iriReference] = []
+        for evidence_item in assertion.evidence_items:
+            try:
+                evidence_items.append(CivicGksEvidence(evidence_item))
+            except CivicGksRecordError as e:
+                _logger.exception(
+                    "Error translating %s to CivicGksEvidence: %s",
+                    evidence_item.name,
+                    str(e),
+                )
+            except Exception as e:
+                _logger.exception(
+                    "Unhandled error translating %s to CivicGksEvidence: %s",
+                    evidence_item.name,
+                    str(e),
+                )
+            finally:
+                # Retain all EID references
+                reported_in.append(f"{LINKS_URL}/evidence/{evidence_item.id}")
 
         return [
             EvidenceLine(
                 hasEvidenceItems=evidence_items,
                 directionOfEvidenceProvided=direction,
                 strengthOfEvidenceProvided=strength,
+                reportedIn=reported_in
             )
         ]
 

--- a/civicpy/exports/civic_gks_record.py
+++ b/civicpy/exports/civic_gks_record.py
@@ -955,7 +955,7 @@ class _CivicGksAssertionRecord(_CivicGksEvidenceAssertionMixin, ABC):
 
         return [
             EvidenceLine(
-                hasEvidenceItems=evidence_items,
+                hasEvidenceItems=evidence_items or None,
                 directionOfEvidenceProvided=direction,
                 strengthOfEvidenceProvided=strength,
                 extensions=[Extension(name="citations", value=eid_links)]

--- a/civicpy/exports/civic_gks_record.py
+++ b/civicpy/exports/civic_gks_record.py
@@ -877,7 +877,11 @@ class _CivicGksAssertionRecord(_CivicGksEvidenceAssertionMixin, ABC):
                     id=f"civic.{organization.type}:{organization.id}",
                     name=organization.name,
                     description=organization.description,
-                    extensions=[Extension(name="is_approved_vcep", value=organization.is_approved_vcep)],
+                    extensions=[
+                        Extension(
+                            name="is_approved_vcep", value=organization.is_approved_vcep
+                        )
+                    ],
                 ),
             )
         ]
@@ -929,7 +933,7 @@ class _CivicGksAssertionRecord(_CivicGksEvidenceAssertionMixin, ABC):
         )
 
         evidence_items: list[CivicGksEvidence] = []
-        reported_in: list[iriReference] = []
+        eid_links: list[str] = []
         for evidence_item in assertion.evidence_items:
             try:
                 evidence_items.append(CivicGksEvidence(evidence_item))
@@ -947,14 +951,14 @@ class _CivicGksAssertionRecord(_CivicGksEvidenceAssertionMixin, ABC):
                 )
             finally:
                 # Retain all EID references
-                reported_in.append(f"{LINKS_URL}/evidence/{evidence_item.id}")
+                eid_links.append(f"{LINKS_URL}/evidence/{evidence_item.id}")
 
         return [
             EvidenceLine(
                 hasEvidenceItems=evidence_items,
                 directionOfEvidenceProvided=direction,
                 strengthOfEvidenceProvided=strength,
-                reportedIn=reported_in
+                extensions=[Extension(name="citations", value=eid_links)]
             )
         ]
 

--- a/civicpy/tests/test_exports.py
+++ b/civicpy/tests/test_exports.py
@@ -126,8 +126,8 @@ def gks_contributions():
             "contributor": {
                 "id": "civic.organization:1",
                 "type": "Agent",
-                "name": "The McDonnell Genome Institute",
-                "description": "The McDonnell Genome Institute (MGI) is a world leader in the fast-paced, constantly changing field of genomics. A truly unique institution, we are pushing the limits of academic research by creating, testing, and implementing new approaches to the study of biology with the goal of understanding human health and disease, as well as evolution and the biology of other organisms.",
+                "name": "CIViC",
+                "description": "The CIViC Organization (formerly “The McDonnell Genome Institute” CIViC organization) comprises the founders, developers, editors, curators, and administrators who build and maintain the knowledgebase, based at Washington University in St. Louis. This group is dedicated to ensuring that high-quality cancer variant interpretations are broadly accessible for precision oncology. One of their main roles is evaluating and synthesizing crowdsourced community contributions into formal clinical Assertions. Once these Assertions meet the strict criteria of the CIViC standard operating procedure, core approval members approve them for 1-star submission to the ClinVar CIViC organization.",
                 "extensions": [{"name": "is_approved_vcep", "value": False}],
             },
             "activityType": "approval.last_reviewed",
@@ -480,6 +480,14 @@ def gks_aid6(
                         "system": "AMP/ASCO/CAP (AAC) Guidelines, 2017",
                     },
                 },
+                "reportedIn": [
+                    "https://civicdb.org/links/evidence/2997",
+                    "https://civicdb.org/links/evidence/879",
+                    "https://civicdb.org/links/evidence/982",
+                    "https://civicdb.org/links/evidence/883",
+                    "https://civicdb.org/links/evidence/968",
+                    "https://civicdb.org/links/evidence/2629"
+                ]
             }
         ],
         "reportedIn": ["https://civicdb.org/links/assertion/6"],

--- a/civicpy/tests/test_exports.py
+++ b/civicpy/tests/test_exports.py
@@ -836,6 +836,22 @@ class TestCivicGksPrognosticAssertion(object):
         assert record.strength.primaryCoding.code.root == "Level A"
         assert record.classification.primaryCoding.code.root == "Tier I"
 
+    @patch.object(civic.Assertion, "evidence_items", new_callable=PropertyMock)
+    @patch.object(civic.Evidence, "is_valid_for_gks_json")
+    def test_citations(self, test_is_valid_for_gks_json,test_evidence_items, aid20):
+        """Test that citations extension is working correctly for EIDs that are not valid for GKS"""
+        test_evidence_items.return_value = [civic.get_evidence_by_id(11881)]
+        test_is_valid_for_gks_json.return_value = False
+
+        record = CivicGksPrognosticAssertion(aid20)
+        assert len(record.hasEvidenceLines) == 1
+        assert record.hasEvidenceLines[0].hasEvidenceItems is None
+        assert len(record.hasEvidenceLines[0].extensions) == 1
+        assert record.hasEvidenceLines[0].extensions[0].model_dump(exclude_none=True) == {
+            "name": "citations",
+            "value": ["https://civicdb.org/links/evidence/11881"]
+        }
+
 
 class TestCivicGksDiagnosticAssertion(object):
     """Test that CivicGksDiagnosticAssertion works as expected"""

--- a/civicpy/tests/test_exports.py
+++ b/civicpy/tests/test_exports.py
@@ -480,13 +480,19 @@ def gks_aid6(
                         "system": "AMP/ASCO/CAP (AAC) Guidelines, 2017",
                     },
                 },
-                "reportedIn": [
-                    "https://civicdb.org/links/evidence/2997",
-                    "https://civicdb.org/links/evidence/879",
-                    "https://civicdb.org/links/evidence/982",
-                    "https://civicdb.org/links/evidence/883",
-                    "https://civicdb.org/links/evidence/968",
-                    "https://civicdb.org/links/evidence/2629"
+                "extensions": [
+                    {
+                        "name": "citations",
+                        "value": [
+                            "https://civicdb.org/links/evidence/2997",
+                            "https://civicdb.org/links/evidence/879",
+                            "https://civicdb.org/links/evidence/982",
+                            "https://civicdb.org/links/evidence/883",
+                            "https://civicdb.org/links/evidence/968",
+                            "https://civicdb.org/links/evidence/2629"
+                        ]
+                    }
+
                 ]
             }
         ],


### PR DESCRIPTION
* This will allows us to retain all references to EIDs that are associated to an AID, even if they fail to translate to CivicGksEvidence