### PR TITLE
Use versioned cache pkl download path matching installed version

### DIFF
--- a/civicpy/__env__.py
+++ b/civicpy/__env__.py
@@ -1,0 +1,61 @@
+from .__version__ import __version__
+from pathlib import Path
+import os
+import requests
+import subprocess
+from packaging.version import Version
+import logging
+from datetime import datetime
+
+
+#get the currently installed civicpy version and warn if it is out of date
+result = subprocess.run(["pip", "index", "versions", "civicpy"], capture_output=True, text=True)
+latest_version = result.stdout.split("LATEST:")[1].strip()
+if Version(__version__) < Version(latest_version):
+    logging.warning("The installed civicpy version is out of date.")
+    logging.warning(f"Latest version: {latest_version}")
+    logging.warning(f"Installed version: {__version__}")
+
+REMOTE_CACHE_URL = os.getenv('CIVICPY_REMOTE_CACHE_URL', False)
+fallback_cache_timeout_days = 7
+
+if REMOTE_CACHE_URL:
+    logging.warning(f"Using REMOTE_CACHE_URL: {REMOTE_CACHE_URL}")
+else:
+    versioned_url = f"https://civicdb.org/downloads/nightly/nightly-civicpy_cache-{__version__}.pkl"
+    generic_url = "https://civicdb.org/downloads/nightly/nightly-civicpy_cache.pkl"
+    use_versioned_url = False
+    response = requests.head(versioned_url, timeout=5)
+    # Checks if the status code is in the 200-399 range
+    if response.status_code == requests.codes.ok:
+        use_versioned_url = True
+        last_modified = response.headers.get('Last-Modified')
+    else:
+        logging.warning(f"Remote cache URL matching your installed civicpy version not found.")
+
+    if use_versioned_url:
+        REMOTE_CACHE_URL = versioned_url
+        logging.warning(f"Using remote cache URL matching your installed civicpy version: {versioned_url}")
+        delta = (datetime.today()-datetime.strptime(last_modified, "%a, %d %b %Y %H:%M:%S GMT")).days
+        logging.warning(f"This remote cache was created on {last_modified} and is {delta} days old.")
+        if Version(__version__) < Version(latest_version):
+            logging.warning("If a newer cache is desired, please update CIViCpy to the latest version and try again.")
+        if delta >=7:
+            fallback_cache_timeout_days = delta + 1
+    else:
+        REMOTE_CACHE_URL = generic_url
+        logging.warning(f"Using generic remote cache URL: {generic_url}")
+        if Version(__version__) < Version(latest_version):
+            logging.warning(f"This cache might not be compatible with your civicpy version. If loading fails, please update CIViCpy to the latest version and try again.")
+
+LOCAL_CACHE_PATH = os.getenv('CIVICPY_CACHE_FILE', False) or \
+    str(Path.home() / '.civicpy' / 'cache.pkl')
+
+CACHE_TIMEOUT_DAYS = os.getenv('CIVICPY_CACHE_TIMEOUT_DAYS', False) or fallback_cache_timeout_days
+# We convert the CACHE_TIMEOUT_DAYS to int
+# if not possible we use the default value
+try:
+    CACHE_TIMEOUT_DAYS = int(CACHE_TIMEOUT_DAYS)
+except TypeError:
+    CACHE_TIMEOUT_DAYS = fallback_cache_timeout_days
+logging.warning(f"Setting cache timeout days to {CACHE_TIMEOUT_DAYS}.")

--- a/civicpy/__env__.py
+++ b/civicpy/__env__.py
@@ -6,15 +6,22 @@ import subprocess
 from packaging.version import Version
 import logging
 from datetime import datetime
+from importlib.metadata import version
+import urllib.request
+import json
 
 
 #get the currently installed civicpy version and warn if it is out of date
-result = subprocess.run(["pip", "index", "versions", "civicpy"], capture_output=True, text=True)
-latest_version = result.stdout.split("LATEST:")[1].strip()
-if Version(__version__) < Version(latest_version):
+PACKAGE = "civicpy"
+installed_version = version(PACKAGE)
+
+with urllib.request.urlopen(f"https://pypi.org/pypi/{PACKAGE}/json") as r:
+    latest_version = json.load(r)["info"]["version"]
+
+if Version(installed_version) < Version(latest_version):
     logging.warning("The installed civicpy version is out of date.")
     logging.warning(f"Latest version: {latest_version}")
-    logging.warning(f"Installed version: {__version__}")
+    logging.warning(f"Installed version: {installed_version}")
 
 REMOTE_CACHE_URL = os.getenv('CIVICPY_REMOTE_CACHE_URL', False)
 fallback_cache_timeout_days = 7
@@ -31,7 +38,7 @@ else:
         use_versioned_url = True
         last_modified = response.headers.get('Last-Modified')
     else:
-        logging.warning(f"Remote cache URL matching your installed civicpy version not found.")
+        logging.warning("Remote cache URL matching your installed civicpy version not found.")
 
     if use_versioned_url:
         REMOTE_CACHE_URL = versioned_url
@@ -46,7 +53,7 @@ else:
         REMOTE_CACHE_URL = generic_url
         logging.warning(f"Using generic remote cache URL: {generic_url}")
         if Version(__version__) < Version(latest_version):
-            logging.warning(f"This cache might not be compatible with your civicpy version. If loading fails, please update CIViCpy to the latest version and try again.")
+            logging.warning("This cache might not be compatible with your civicpy version. If loading fails, please update CIViCpy to the latest version and try again.")
 
 LOCAL_CACHE_PATH = os.getenv('CIVICPY_CACHE_FILE', False) or \
     str(Path.home() / '.civicpy' / 'cache.pkl')

--- a/civicpy/__init__.py
+++ b/civicpy/__init__.py
@@ -1,21 +1,4 @@
 from .__version__ import __version__
-from pathlib import Path
-import os
-
-REMOTE_CACHE_URL = os.getenv('CIVICPY_REMOTE_CACHE_URL', False) or \
-    "https://civicdb.org/downloads/nightly/nightly-civicpy_cache.pkl"
-LOCAL_CACHE_PATH = os.getenv('CIVICPY_CACHE_FILE', False) or \
-    str(Path.home() / '.civicpy' / 'cache.pkl')
-CACHE_TIMEOUT_DAYS = os.getenv('CIVICPY_CACHE_TIMEOUT_DAYS', False) or 7
-# We convert the CACHE_TIMEOUT_DAYS to int
-# if not possible we use the default value
-try:
-    CACHE_TIMEOUT_DAYS = int(CACHE_TIMEOUT_DAYS)
-except TypeError:
-    CACHE_TIMEOUT_DAYS = 7
-
-TEST_CACHE_PATH = str(Path(__file__).parent / 'data' / 'test_cache.pkl')
-
 
 def version():
     return __version__

--- a/civicpy/civic.py
+++ b/civicpy/civic.py
@@ -13,7 +13,7 @@ import time
 
 import re
 
-from civicpy import REMOTE_CACHE_URL, LOCAL_CACHE_PATH, CACHE_TIMEOUT_DAYS
+from civicpy.__env__ import REMOTE_CACHE_URL, LOCAL_CACHE_PATH, CACHE_TIMEOUT_DAYS
 from civicpy import graphql_payloads
 from civicpy import utils
 

--- a/civicpy/cli.py
+++ b/civicpy/cli.py
@@ -1,7 +1,8 @@
 from pathlib import Path
 import click
 import logging
-from civicpy import LOCAL_CACHE_PATH, civic
+from civicpy import civic
+from civicpy.__env__ import LOCAL_CACHE_PATH
 from civicpy.exports.civic_gks_record import (
     CivicGksRecordError,
     CivicGksPredictiveAssertion,


### PR DESCRIPTION
Pull from the versioned cache pkl release matching a the currently installed version.

Also output a bunch of warning messages for outdated versions, which paths are being used, and what timeout is being set.

Depends on: https://github.com/griffithlab/civic-v2/pull/1409

Closes #216 