### PR TITLE
feat: add clinvar_accession to gks assertions

### DIFF
--- a/civicpy/civic.py
+++ b/civicpy/civic.py
@@ -1877,6 +1877,7 @@ class Approval(CivicRecord):
             "status",
             "last_reviewed",
             "ready_for_clinvar_submission",
+            "clinvar_accession",
         }
     )
 

--- a/civicpy/exports/civic_gks_record.py
+++ b/civicpy/exports/civic_gks_record.py
@@ -908,6 +908,12 @@ class CivicGksAssertion(
         )
         contributions = self.get_contributions(approval) if approval else None
 
+        extensions = []
+        if approval and approval.clinvar_accession:
+            extensions.append(
+                Extension(name="clinvar_accession", value=approval.clinvar_accession)
+            )
+
         super().__init__(
             id=f"civic.aid:{assertion.id}",
             contributions=contributions,
@@ -919,6 +925,7 @@ class CivicGksAssertion(
             strength=strength,
             hasEvidenceLines=self.get_evidence_lines(assertion, level),
             reportedIn=[iriReference(f"{LINKS_URL}/assertion/{assertion.id}")],
+            extensions=extensions or None,
         )
 
     @staticmethod

--- a/civicpy/graphql_payloads.py
+++ b/civicpy/graphql_payloads.py
@@ -623,6 +623,7 @@ def _construct_get_assertion_payload():
                 approvals {
                   nodes {
                     id
+                    clinvar_accession: clinvarAccession
                   }
                 }
                 therapies {
@@ -685,6 +686,7 @@ def _construct_get_all_assertions_payload():
                     approvals {
                       nodes {
                         id
+                        clinvar_accession: clinvarAccession
                       }
                     }
                     therapies {
@@ -959,6 +961,7 @@ def _construct_get_approval_payload():
                 status
                 last_reviewed: lastReviewed
                 ready_for_clinvar_submission: readyForClinvarSubmission
+                clinvar_accession: clinvarAccession
             }
         }"""
 
@@ -983,6 +986,7 @@ def _construct_get_all_approvals_payload():
                 status
                 last_reviewed: lastReviewed
                 ready_for_clinvar_submission: readyForClinvarSubmission
+                clinvar_accession: clinvarAccession
               }
             }
         }

--- a/civicpy/tests/test_civic.py
+++ b/civicpy/tests/test_civic.py
@@ -861,6 +861,9 @@ class TestApproval(object):
         assert a.organization_id == 14
         assert a.assertion_id == 101
 
+        a = civic.get_approval_by_id(6)
+        assert a.clinvar_accession == "SCV007542591"
+
     def test_search_approvals_by_organization_id(self):
         approvals = civic.search_approvals_by_organization_id(1)
         assert len(approvals) >= 1

--- a/civicpy/tests/test_exports.py
+++ b/civicpy/tests/test_exports.py
@@ -109,12 +109,6 @@ def aid117():
 
 
 @pytest.fixture(scope="module")
-def approval4():
-    """Create test fixture for active approval"""
-    return civic.get_approval_by_id(4)
-
-
-@pytest.fixture(scope="module")
 def gks_contributions():
     return [
         {
@@ -436,7 +430,6 @@ def gks_eid2997(
 
 @pytest.fixture(scope="module")
 def gks_aid6(
-    gks_contributions,
     gks_method,
     gks_therapeutic_proposition,
     gks_eid2997,
@@ -450,7 +443,6 @@ def gks_aid6(
 
     params = {
         "id": "civic.aid:6",
-        "contributions": gks_contributions,
         "description": "L858R is among the most common sensitizing EGFR mutations in NSCLC, and is assessed via DNA mutational analysis, including Sanger sequencing and next generation sequencing methods. Tyrosine kinase inhibitor afatinib is FDA approved as a first line systemic therapy in NSCLC with sensitizing EGFR mutation (civic.EID:2997).",
         "type": "Statement",
         "specifiedBy": gks_method,
@@ -762,9 +754,9 @@ class TestCivicGksEvidence(object):
 class TestCivicGksAssertion(object):
     """Test that CivicGksAssertion works as expected"""
 
-    def test_valid_single_therapy(self, aid6, approval4, gks_aid6):
+    def test_valid_single_therapy(self, aid6, gks_aid6):
         """Test that single therapy works as expected"""
-        record = CivicGksAssertion(aid6, approval=approval4)
+        record = CivicGksAssertion(aid6)
         assert isinstance(record, VariantClinicalSignificanceStatement)
         assert len(record.hasEvidenceLines) == 1
 
@@ -927,6 +919,14 @@ class TestCivicGksDiagnosticAssertion(object):
             ignore_order=True,
         )
         assert diff == {}
+
+    def test_clinvar_accession_ext(self):
+        a = civic.get_assertion_by_id(193)
+        record = CivicGksAssertion(a, approval=a.approvals[0])
+        assert isinstance(record, VariantClinicalSignificanceStatement)
+        assert [ext.model_dump(exclude_none=True) for ext in record.extensions] == [
+            {"name": "clinvar_accession", "value": "SCV007542591"}
+        ]
 
     def test_invalid(self, aid117):
         """Test that unsupported assertion types raise exceptions"""


### PR DESCRIPTION
close #229

* ClinVar This will create an update submission if clinvar_accession extension is provided, otherwise it will create a novel submission. See ClinVar This PR: [feat: add support for handling updates in gks json #19](https://github.com/clingen-data-model/clinvar-this/pull/19)