### PR TITLE
feat: add back `create_gks_record_from_assertion`

### DIFF
--- a/civicpy/cli.py
+++ b/civicpy/cli.py
@@ -5,7 +5,9 @@ from civicpy import civic
 from civicpy.__env__ import LOCAL_CACHE_PATH
 from civicpy.exports.civic_gks_record import (
     CivicGksRecordError,
-    CivicGksClinSigAssertion
+    CivicGksClinSigAssertion,
+    ClinVarSubmissionType,
+    create_gks_record_from_assertion,
 )
 from civicpy.exports.civic_gks_writer import CivicGksWriter, GksAssertionError
 from civicpy.exports.civic_vcf_writer import CivicVcfWriter
@@ -72,6 +74,16 @@ def create_vcf(vcf_file_path, include_status):
     type=int,
 )
 @click.option(
+    "--submission-type",
+    type=click.Choice(
+        [s.value for s in ClinVarSubmissionType],
+        case_sensitive=True,
+    ),
+    help="The ClinVar submission type to generate GKS JSON for.",
+    default=ClinVarSubmissionType.CLINICAL_IMPACT.value,
+    show_default=True,
+)
+@click.option(
     "-o",
     "--output-json",
     required=True,
@@ -83,13 +95,21 @@ def create_vcf(vcf_file_path, include_status):
         path_type=Path,
     ),
 )
-def create_gks_json(organization_id: int, output_json: Path) -> None:
+def create_gks_json(
+    organization_id: int, submission_type: ClinVarSubmissionType, output_json: Path
+) -> None:
     """Create a JSON file for CIViC assertion records approved by a specific organization that are ready for ClinVar submission, represented as GKS objects.
 
     For now, we will only support simple molecular profiles and diagnostic, prognostic,
     or predictive assertions.
 
+    ClinVar only supports submitting records of the same submission type for a
+    given assertion criteria:
+    * Clinical Impact -> diagnostic, prognostic, or predictive assertion
+
     :param organization_id: The CIViC organization ID that approved the assertion(s) for submission to ClinVar
+    :param submission_type: The ClinVar submission type to generate GKS JSON for.
+        Defaults to clinical impact.
     :param output_json: The output file path to write the JSON file to
     """
     try:
@@ -107,7 +127,9 @@ def create_gks_json(organization_id: int, output_json: Path) -> None:
         assertion = approval.assertion
         if assertion.is_valid_for_gks_json(emit_warnings=True):
             try:
-                gks_record = CivicGksClinSigAssertion(assertion, approval=approval)
+                gks_record = create_gks_record_from_assertion(
+                    assertion, approval=approval, submission_type_filter=submission_type
+                )
             except (CivicGksRecordError, NotImplementedError) as e:
                 errors.append(
                     GksAssertionError(assertion_id=assertion.id, message=str(e))

--- a/civicpy/cli.py
+++ b/civicpy/cli.py
@@ -5,7 +5,7 @@ from civicpy import civic
 from civicpy.__env__ import LOCAL_CACHE_PATH
 from civicpy.exports.civic_gks_record import (
     CivicGksRecordError,
-    CivicGksAssertion
+    CivicGksClinSigAssertion
 )
 from civicpy.exports.civic_gks_writer import CivicGksWriter, GksAssertionError
 from civicpy.exports.civic_vcf_writer import CivicVcfWriter
@@ -98,7 +98,7 @@ def create_gks_json(organization_id: int, output_json: Path) -> None:
         logging.exception("Error getting organization %i", organization_id)
         return
 
-    records: list[CivicGksAssertion] = []
+    records: list[CivicGksClinSigAssertion] = []
     errors: list[GksAssertionError] = []
 
     for approval in civic.get_all_approvals_ready_for_clinvar_submission_for_org(
@@ -107,7 +107,7 @@ def create_gks_json(organization_id: int, output_json: Path) -> None:
         assertion = approval.assertion
         if assertion.is_valid_for_gks_json(emit_warnings=True):
             try:
-                gks_record = CivicGksAssertion(assertion, approval=approval)
+                gks_record = CivicGksClinSigAssertion(assertion, approval=approval)
             except (CivicGksRecordError, NotImplementedError) as e:
                 errors.append(
                     GksAssertionError(assertion_id=assertion.id, message=str(e))

--- a/civicpy/exports/civic_gks_record.py
+++ b/civicpy/exports/civic_gks_record.py
@@ -4,33 +4,33 @@
   Clinical Significance Statements that follow the AMP/ASCO/CAP 2017 guidelines
 """
 
-from enum import Enum
 import logging
 import re
+from enum import Enum
 from types import MappingProxyType
 
 from ga4gh.cat_vrs.models import CategoricalVariant
 from ga4gh.core.models import (
     Coding,
     ConceptMapping,
-    iriReference,
     Extension,
     MappableConcept,
     Relation,
+    iriReference,
 )
 from ga4gh.va_spec.aac_2017 import (
+    AMP_ASCO_CAP_CLASSIFICATION_MAP,
     AmpAscoCapClassificationCode,
     AmpAscoCapEvidenceLineStrength,
-    VariantClinicalSignificanceStatement,
-    AMP_ASCO_CAP_CLASSIFICATION_MAP,
     DiagnosticEvidenceLine,
     PrognosticEvidenceLine,
     TherapeuticEvidenceLine,
+    VariantClinicalSignificanceStatement,
 )
 from ga4gh.va_spec.base import (
     Agent,
-    Contribution,
     ConditionSet,
+    Contribution,
     DiagnosticPredicate,
     Direction,
     Document,
@@ -48,20 +48,21 @@ from ga4gh.va_spec.base import (
 )
 from ga4gh.vrs.models import Expression, Syntax
 from pydantic import BaseModel
+
 from civicpy.civic import (
     LINKS_URL,
+    Approval,
     Assertion,
     Coordinate,
-    Approval,
-    Evidence,
     Disease,
+    Evidence,
     Gene,
+    GeneVariant,
+    MolecularProfile,
     Organization,
     Phenotype,
     Source,
     Therapy,
-    GeneVariant,
-    MolecularProfile,
 )
 
 _logger = logging.getLogger(__name__)
@@ -94,6 +95,26 @@ class CivicEvidenceAssertionType(str, Enum):
     PREDICTIVE = "PREDICTIVE"
     PROGNOSTIC = "PROGNOSTIC"
     DIAGNOSTIC = "DIAGNOSTIC"
+
+
+CLINICAL_SIGNIFICANCE_ASSERTION_TYPES = [
+    CivicEvidenceAssertionType.PREDICTIVE.value,
+    CivicEvidenceAssertionType.PROGNOSTIC.value,
+    CivicEvidenceAssertionType.DIAGNOSTIC.value,
+]
+
+
+class ClinVarSubmissionType(str, Enum):
+    """Define supported submission types to ClinVar"""
+
+    CLINICAL_IMPACT = "clinical_impact"
+
+
+ASSERTION_TYPES_BY_CLINVAR_SUBMISSION_TYPE = MappingProxyType(
+    {
+        ClinVarSubmissionType.CLINICAL_IMPACT: CLINICAL_SIGNIFICANCE_ASSERTION_TYPES,
+    }
+)
 
 
 class CivicEvidenceLevel(str, Enum):
@@ -945,9 +966,16 @@ class CivicGksClinSigAssertion(
 
         :param assertion: CIViC assertion record
         :param approval: CIViC approval for the assertion, defaults to None
-        :raises CivicGksRecordError: If CIViC assertion is not able to be represented as
-            GKS object
+        :raises CivicGksRecordError: If CIViC assertion type is not one of
+            ``CLINICAL_SIGNIFICANCE_ASSERTION_TYPES`` or if assertion is not
+            able to be represented as GKS object
         """
+        if assertion.assertion_type not in CLINICAL_SIGNIFICANCE_ASSERTION_TYPES:
+            err_msg = (
+                f"Assertion type must be one of {CLINICAL_SIGNIFICANCE_ASSERTION_TYPES}"
+            )
+            raise CivicGksRecordError(err_msg)
+
         if not assertion.is_valid_for_gks_json(emit_warnings=True):
             err_msg = "Assertion is not valid for GKS."
             raise CivicGksRecordError(err_msg)
@@ -1091,3 +1119,38 @@ class CivicGksClinSigAssertion(
             assertion, assertion.assertion_type, is_clinical_significance_prop=True
         )
         return VariantClinicalSignificanceProposition(**params)
+
+
+def create_gks_record_from_assertion(
+    assertion: Assertion,
+    approval: Approval | None = None,
+    submission_type_filter: ClinVarSubmissionType | None = None,
+) -> CivicGksClinSigAssertion:
+    """Create GKS Record from CIViC Assertion
+
+    :param assertion: CIViC assertion record
+    :param approval: CIViC approval for the assertion, defaults to None
+    :param submission_type_filter: Optional ClinVar submission type used to
+        restrict which assertion types may be translated
+    :raises NotImplementedError: If GKS Record translation is not yet supported.
+        Currently, only the following assertion types are supported: DIAGNOSTIC,
+        PREDICTIVE, and PROGNOSTIC.
+        Or if the assertion type is excluded by the provided ClinVar submission type
+            filter.
+    :return: GKS Assertion Record object
+    """
+    assertion_type = assertion.assertion_type
+
+    if submission_type_filter:
+        allowed_assertion_types = ASSERTION_TYPES_BY_CLINVAR_SUBMISSION_TYPE[
+            submission_type_filter
+        ]
+        if assertion_type not in allowed_assertion_types:
+            err_msg = f"Assertion type {assertion_type} is not supported for ClinVar submission type {submission_type_filter.value}"
+            raise NotImplementedError(err_msg)
+
+    if assertion_type in CLINICAL_SIGNIFICANCE_ASSERTION_TYPES:
+        return CivicGksClinSigAssertion(assertion, approval=approval)
+
+    err_msg = f"Assertion type {assertion_type} is not currently supported"
+    raise NotImplementedError(err_msg)

--- a/civicpy/exports/civic_gks_record.py
+++ b/civicpy/exports/civic_gks_record.py
@@ -1,4 +1,8 @@
-"""Module for representing CIViC assertion record as GKS AAC 2017 Study Statement"""
+"""Module for representing CIViC records as GKS representations
+
+* CIViC Predictive, Prognostic, and Diagnostic Assertions map to Variant
+  Clinical Significance Statements that follow the AMP/ASCO/CAP 2017 guidelines
+"""
 
 from enum import Enum
 import logging
@@ -623,6 +627,8 @@ class CivicGksTherapyGroup(TherapyGroup):
 
 
 class _CivicGksEvidenceAssertionMixin:
+    """Mixin for CIViC Evidence and Assertions"""
+
     @staticmethod
     def get_allele_origin_qualifier(record: Evidence | Assertion) -> MappableConcept:
         """Get GKS allele origin qualifier
@@ -877,10 +883,53 @@ class CivicGksEvidence(Statement, _CivicGksEvidenceAssertionMixin):
         )
 
 
-class CivicGksAssertion(
-    VariantClinicalSignificanceStatement, _CivicGksEvidenceAssertionMixin
+class _CivicGksAssertionMixin:
+    """Mixin for CIViC Assertions"""
+
+    @staticmethod
+    def get_contributions(approval: Approval) -> list[Contribution]:
+        """Get contributions for an approval
+
+        :param approval: Approval for assertion
+        :return: List of contributions, with one item containing when the approval was
+            last reviewed an organization.
+            Will include an extension, `is_approved_vcep`.
+        """
+        organization: Organization = approval.organization
+        return [
+            Contribution(
+                activityType=f"{approval.type}.last_reviewed",
+                date=approval.last_reviewed.split("T", 1)[0],
+                contributor=Agent(
+                    id=f"civic.{organization.type}:{organization.id}",
+                    name=organization.name,
+                    description=organization.description,
+                    extensions=[
+                        Extension(
+                            name="is_approved_vcep", value=organization.is_approved_vcep
+                        )
+                    ],
+                ),
+            )
+        ]
+
+    @staticmethod
+    def get_reported_in(assertion: Assertion) -> list[iriReference]:
+        """Get reported in information for an assertion
+
+        :param assertion: CIViC assertion record
+        :return: List of CIViC links to records which the assertion is reported in
+        """
+        return [iriReference(f"{LINKS_URL}/assertion/{assertion.id}")]
+
+
+class CivicGksClinSigAssertion(
+    VariantClinicalSignificanceStatement,
+    _CivicGksAssertionMixin,
+    _CivicGksEvidenceAssertionMixin,
 ):
-    """Class for CIViC assertion record represented as GKS
+    """Class for CIViC predictive, prognostic, or diagnostic assertion record
+    represented as GKS
 
     :param assertion: CIViC assertion record
     :raises CivicGksRecordError: If CIViC assertion is not able to be represented as
@@ -892,7 +941,7 @@ class CivicGksAssertion(
         assertion: Assertion,
         approval: Approval | None = None,
     ) -> None:
-        """Initialize _CivicGksAssertionRecord class
+        """Initialize CivicGksClinSigAssertion class
 
         :param assertion: CIViC assertion record
         :param approval: CIViC approval for the assertion, defaults to None
@@ -924,34 +973,9 @@ class CivicGksAssertion(
             classification=classification,
             strength=strength,
             hasEvidenceLines=self.get_evidence_lines(assertion, level),
-            reportedIn=[iriReference(f"{LINKS_URL}/assertion/{assertion.id}")],
+            reportedIn=self.get_reported_in(assertion),
             extensions=extensions or None,
         )
-
-    @staticmethod
-    def get_contributions(approval: Approval) -> list[Contribution]:
-        """Get contributions for an approval
-
-        :param approval: Approval for assertion
-        :return: List of contributions containing when the approval was last reviewed
-        """
-        organization: Organization = approval.organization
-        return [
-            Contribution(
-                activityType=f"{approval.type}.last_reviewed",
-                date=approval.last_reviewed.split("T", 1)[0],
-                contributor=Agent(
-                    id=f"civic.{organization.type}:{organization.id}",
-                    name=organization.name,
-                    description=organization.description,
-                    extensions=[
-                        Extension(
-                            name="is_approved_vcep", value=organization.is_approved_vcep
-                        )
-                    ],
-                ),
-            )
-        ]
 
     def get_classification_strength_level(
         self,

--- a/civicpy/exports/civic_gks_writer.py
+++ b/civicpy/exports/civic_gks_writer.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
-from civicpy.exports.civic_gks_record import CivicGksAssertion
+from civicpy.exports.civic_gks_record import CivicGksClinSigAssertion
 
 
 def get_pkg_version(name: str) -> str:
@@ -43,7 +43,7 @@ class GksAssertionError(BaseModel):
 class GksOutput(BaseModel):
     """Define model for representing GKS JSON output"""
 
-    gks_records: list[CivicGksAssertion]
+    gks_records: list[CivicGksClinSigAssertion]
     metadata: GksOutputMetadata
     failed_assertion_ids: list[int] = []
     errors: list[GksAssertionError] = []
@@ -60,7 +60,7 @@ class CivicGksWriter:
     def __init__(
         self,
         filepath: Path,
-        gks_records: list[CivicGksAssertion],
+        gks_records: list[CivicGksClinSigAssertion],
         errors: list[GksAssertionError] | None = None,
     ):
         """Initialize CivicGksWriter class

--- a/civicpy/tests/test_civic.py
+++ b/civicpy/tests/test_civic.py
@@ -103,7 +103,7 @@ class TestEvidence(object):
         evidence = v600e_mp.evidence[0]
         assert evidence.molecular_profile.name == "BRAF V600E"
         assert evidence.statement == evidence.description
-        assert len(evidence.assertions) == 0
+        assert len(evidence.assertions) == 1
         assert evidence.disease.name == "Skin Melanoma"
         assert len(evidence.therapies) == 1
         assert len(evidence.phenotypes) == 0

--- a/civicpy/tests/test_exports.py
+++ b/civicpy/tests/test_exports.py
@@ -14,7 +14,7 @@ from civicpy.exports.civic_gks_record import (
     CivicGksEvidence,
     CivicGksMolecularProfile,
     CivicGksRecordError,
-    CivicGksAssertion,
+    CivicGksClinSigAssertion,
     CivicGksTherapyGroup,
 )
 
@@ -751,12 +751,12 @@ class TestCivicGksEvidence(object):
             CivicGksEvidence(eid9285)
 
 
-class TestCivicGksAssertion(object):
-    """Test that CivicGksAssertion works as expected"""
+class TestCivicGksClinSigAssertion(object):
+    """Test that CivicGksClinSigAssertion works as expected"""
 
     def test_valid_single_therapy(self, aid6, gks_aid6):
         """Test that single therapy works as expected"""
-        record = CivicGksAssertion(aid6)
+        record = CivicGksClinSigAssertion(aid6)
         assert isinstance(record, VariantClinicalSignificanceStatement)
         assert len(record.hasEvidenceLines) == 1
 
@@ -778,7 +778,7 @@ class TestCivicGksAssertion(object):
 
     def test_valid_combination_therapy(self, aid7):
         """Test that combination therapy works as expected"""
-        record = CivicGksAssertion(aid7)
+        record = CivicGksClinSigAssertion(aid7)
         assert isinstance(record, VariantClinicalSignificanceStatement)
         assert len(record.hasEvidenceLines) == 1
         assert len(record.hasEvidenceLines[0].hasEvidenceItems) == 4
@@ -825,7 +825,7 @@ class TestCivicGksAssertion(object):
         test_evidence_items.return_value = []
         test_hgvs_expressions.return_value = None
         test_mane_select_transcript.return_value = None
-        record = CivicGksAssertion(aid19)
+        record = CivicGksClinSigAssertion(aid19)
         assert isinstance(record, VariantClinicalSignificanceStatement)
         assert len(record.hasEvidenceLines) == 1
         therapy = record.hasEvidenceLines[0].targetProposition.objectTherapeutic.root
@@ -837,7 +837,7 @@ class TestCivicGksAssertion(object):
 
     def test_valid_prognostic(self, aid20):
         """Test that valid prognostic assertion works as expected"""
-        record = CivicGksAssertion(aid20)
+        record = CivicGksClinSigAssertion(aid20)
         assert isinstance(record, VariantClinicalSignificanceStatement)
         assert len(record.hasEvidenceLines) == 1
         assert len(record.hasEvidenceLines[0].hasEvidenceItems) == 6
@@ -850,18 +850,20 @@ class TestCivicGksAssertion(object):
 
     @patch.object(civic.Assertion, "evidence_items", new_callable=PropertyMock)
     @patch.object(civic.Evidence, "is_valid_for_gks_json")
-    def test_citations(self, test_is_valid_for_gks_json,test_evidence_items, aid20):
+    def test_citations(self, test_is_valid_for_gks_json, test_evidence_items, aid20):
         """Test that citations extension is working correctly for EIDs that are not valid for GKS"""
         test_evidence_items.return_value = [civic.get_evidence_by_id(11881)]
         test_is_valid_for_gks_json.return_value = False
 
-        record = CivicGksAssertion(aid20)
+        record = CivicGksClinSigAssertion(aid20)
         assert len(record.hasEvidenceLines) == 1
         assert record.hasEvidenceLines[0].hasEvidenceItems is None
         assert len(record.hasEvidenceLines[0].extensions) == 1
-        assert record.hasEvidenceLines[0].extensions[0].model_dump(exclude_none=True) == {
+        assert record.hasEvidenceLines[0].extensions[0].model_dump(
+            exclude_none=True
+        ) == {
             "name": "citations",
-            "value": ["https://civicdb.org/links/evidence/11881"]
+            "value": ["https://civicdb.org/links/evidence/11881"],
         }
 
 
@@ -877,7 +879,7 @@ class TestCivicGksDiagnosticAssertion(object):
         gks_aid115_object_condition,
     ):
         """Test that valid diagnostic assertion works as expected"""
-        record = CivicGksAssertion(aid9)
+        record = CivicGksClinSigAssertion(aid9)
         assert isinstance(record, VariantClinicalSignificanceStatement)
         assert len(record.hasEvidenceLines) == 1
         assert len(record.hasEvidenceLines[0].hasEvidenceItems) == 2
@@ -895,7 +897,7 @@ class TestCivicGksDiagnosticAssertion(object):
         )
 
         # Single phenotype (complex condition set)
-        record = CivicGksAssertion(aid93)
+        record = CivicGksClinSigAssertion(aid93)
         assert isinstance(record, VariantClinicalSignificanceStatement)
         record_object_condition = record.proposition.objectCondition
         assert isinstance(record_object_condition, Condition)
@@ -908,7 +910,7 @@ class TestCivicGksDiagnosticAssertion(object):
         assert diff == {}
 
         # Phenotypes (complex condition set)
-        record = CivicGksAssertion(aid115)
+        record = CivicGksClinSigAssertion(aid115)
         assert isinstance(record, VariantClinicalSignificanceStatement)
         record_object_condition = record.proposition.objectCondition
         assert isinstance(record_object_condition, Condition)
@@ -922,7 +924,7 @@ class TestCivicGksDiagnosticAssertion(object):
 
     def test_clinvar_accession_ext(self):
         a = civic.get_assertion_by_id(193)
-        record = CivicGksAssertion(a, approval=a.approvals[0])
+        record = CivicGksClinSigAssertion(a, approval=a.approvals[0])
         assert isinstance(record, VariantClinicalSignificanceStatement)
         assert [ext.model_dump(exclude_none=True) for ext in record.extensions] == [
             {"name": "clinvar_accession", "value": "SCV007542591"}
@@ -934,4 +936,4 @@ class TestCivicGksDiagnosticAssertion(object):
         with pytest.raises(
             CivicGksRecordError, match=r"Assertion is not valid for GKS."
         ):
-            CivicGksAssertion(aid117)
+            CivicGksClinSigAssertion(aid117)

--- a/civicpy/tests/test_exports.py
+++ b/civicpy/tests/test_exports.py
@@ -1,22 +1,25 @@
+import re
 from copy import deepcopy
 from unittest.mock import PropertyMock, patch
+
 import pytest
 from deepdiff import DeepDiff
-from ga4gh.va_spec.base import Condition, ConditionSet, Statement, TherapyGroup
 from ga4gh.va_spec.aac_2017 import (
     VariantClinicalSignificanceStatement,
 )
-
+from ga4gh.va_spec.base import Condition, ConditionSet, Statement, TherapyGroup
 
 from civicpy import civic
-from civicpy.exports.civic_vcf_record import CivicVcfRecord
 from civicpy.exports.civic_gks_record import (
+    CivicGksClinSigAssertion,
     CivicGksEvidence,
     CivicGksMolecularProfile,
     CivicGksRecordError,
-    CivicGksClinSigAssertion,
     CivicGksTherapyGroup,
+    ClinVarSubmissionType,
+    create_gks_record_from_assertion,
 )
+from civicpy.exports.civic_vcf_record import CivicVcfRecord
 
 
 # snv
@@ -106,6 +109,12 @@ def aid115():
 def aid117():
     """Create test fixture for assertion not supported for GKS"""
     return civic.get_assertion_by_id(117)
+
+
+@pytest.fixture(scope="module")
+def aid202():
+    """Create test fixture for oncogenic assertion"""
+    return civic.get_assertion_by_id(202)
 
 
 @pytest.fixture(scope="module")
@@ -934,6 +943,81 @@ class TestCivicGksDiagnosticAssertion(object):
         """Test that unsupported assertion types raise exceptions"""
 
         with pytest.raises(
-            CivicGksRecordError, match=r"Assertion is not valid for GKS."
+            CivicGksRecordError,
+            match=re.escape(
+                "Assertion type must be one of ['PREDICTIVE', 'PROGNOSTIC', 'DIAGNOSTIC']"
+            ),
         ):
             CivicGksClinSigAssertion(aid117)
+
+
+class TestCivicGksRecord(object):
+    """Test that GKS Record helper functions work correctly"""
+
+    def test_unsupported_assertion_type(self):
+        """Test that unsupported assertion types raise NotImplementedError"""
+
+        with pytest.raises(
+            NotImplementedError,
+            match=r"Assertion type PREDISPOSING is not currently supported",
+        ):
+            create_gks_record_from_assertion(civic.get_assertion_by_id(17))
+
+    @pytest.mark.parametrize(
+        (
+            "civic_assertion_fixture_name",
+            "submission_type_filter",
+            "should_raise_error",
+        ),
+        (
+            [
+                "aid202",
+                ClinVarSubmissionType.CLINICAL_IMPACT,
+                True,
+            ],
+            [
+                "aid9",
+                ClinVarSubmissionType.CLINICAL_IMPACT,
+                False,
+            ],
+            [
+                "aid20",
+                ClinVarSubmissionType.CLINICAL_IMPACT,
+                False,
+            ],
+            [
+                "aid6",
+                ClinVarSubmissionType.CLINICAL_IMPACT,
+                False,
+            ],
+        ),
+    )
+    def test_create_gks_record_from_assertion_filter(
+        self,
+        request,
+        civic_assertion_fixture_name,
+        submission_type_filter,
+        should_raise_error,
+    ):
+        """Test that create_gks_record_from_assertion works correctly when submission filter is applied"""
+        civic_aid = request.getfixturevalue(civic_assertion_fixture_name)
+        if should_raise_error:
+            with pytest.raises(
+                NotImplementedError,
+                match=rf"Assertion type {civic_aid.assertion_type} is not supported for ClinVar submission type {submission_type_filter.value}",
+            ):
+                create_gks_record_from_assertion(
+                    civic_aid, submission_type_filter=submission_type_filter
+                )
+        else:
+            assert create_gks_record_from_assertion(
+                civic_aid, submission_type_filter=submission_type_filter
+            )
+
+    def test_clinvar_accession_ext(self):
+        a = civic.get_assertion_by_id(193)
+        record = create_gks_record_from_assertion(a, approval=a.approvals[0])
+        assert isinstance(record, VariantClinicalSignificanceStatement)
+        assert [ext.model_dump(exclude_none=True) for ext in record.extensions] == [
+            {"name": "clinvar_accession", "value": "SCV007542591"}
+        ]


### PR DESCRIPTION
* This was removed in #223, but is needed for #217 (originally in #226)
* Adds `--submission-type` option to create-gks-json