### PR TITLE
fix!: remove temp citations ext, use reportedIn instead

### DIFF
--- a/civicpy/exports/civic_gks_record.py
+++ b/civicpy/exports/civic_gks_record.py
@@ -941,7 +941,12 @@ class _CivicGksAssertionMixin:
         :param assertion: CIViC assertion record
         :return: List of CIViC links to records which the assertion is reported in
         """
-        return [iriReference(f"{LINKS_URL}/assertion/{assertion.id}")]
+        reported_in: list[iriReference] = [
+            iriReference(f"{LINKS_URL}/assertion/{assertion.id}")
+        ]
+        for evidence_item in assertion.evidence_items or []:
+            reported_in.append(iriReference(f"{LINKS_URL}/evidence/{evidence_item.id}"))
+        return reported_in
 
 
 class CivicGksClinSigAssertion(
@@ -1065,7 +1070,6 @@ class CivicGksClinSigAssertion(
         )
 
         evidence_items: list[CivicGksEvidence] = []
-        eid_links: list[str] = []
         for evidence_item in assertion.evidence_items:
             try:
                 evidence_items.append(CivicGksEvidence(evidence_item))
@@ -1081,9 +1085,6 @@ class CivicGksClinSigAssertion(
                     evidence_item.name,
                     str(e),
                 )
-            finally:
-                # Retain all EID references
-                eid_links.append(f"{LINKS_URL}/evidence/{evidence_item.id}")
 
         if assertion.assertion_type == CivicEvidenceAssertionType.PREDICTIVE:
             evidence_line_cls = TherapeuticEvidenceLine
@@ -1103,7 +1104,6 @@ class CivicGksClinSigAssertion(
                 strengthOfEvidenceProvided=MappableConcept(
                     primaryCoding=(Coding(code=level, system=System.AMP_ASCO_CAP))
                 ),
-                extensions=[Extension(name="citations", value=eid_links)]
             ).root
         ]
 

--- a/civicpy/exports/civic_gks_record.py
+++ b/civicpy/exports/civic_gks_record.py
@@ -835,22 +835,24 @@ class CivicGksSource(Document):
     :param source: CIViC source record
     """
 
-    def __init__(self, source: Source) -> None:
+    def __init__(self, source: Source, urls: list[str] | None = None) -> None:
         """Initialize CivicGksSource class
 
         :param source: CIViC source record
+        :param urls: List of additional URLs to include in the document
         """
-        urls = [f"{LINKS_URL}/source/{source.id}", source.source_url]
+        source_urls = urls or []
+        source_urls.extend([f"{LINKS_URL}/source/{source.id}", source.source_url])
         pmid = source.citation_id if source.source_type == "PUBMED" else None
         if pmc_id := source.pmc_id:
-            urls.append(f"https://www.ncbi.nlm.nih.gov/pmc/articles/{pmc_id}")
+            source_urls.append(f"https://www.ncbi.nlm.nih.gov/pmc/articles/{pmc_id}")
 
         super().__init__(
             id=f"civic.sid:{source.id}",
             name=source.citation,
             title=source.title,
             pmid=pmid,
-            urls=urls,
+            urls=source_urls,
         )
 
 
@@ -911,8 +913,10 @@ class CivicGksEvidence(Statement, _CivicGksEvidenceAssertionMixin):
                 CivicEvidenceLevel(evidence_item.evidence_level)
             ),
             reportedIn=[
-                CivicGksSource(evidence_item.source),
-                iriReference(f"{LINKS_URL}/evidence/{evidence_item.id}"),
+                CivicGksSource(
+                    evidence_item.source,
+                    urls=[f"{LINKS_URL}/evidence/{evidence_item.id}"],
+                ),
             ],
         )
 
@@ -948,17 +952,21 @@ class _CivicGksAssertionMixin:
         ]
 
     @staticmethod
-    def get_reported_in(assertion: Assertion) -> list[iriReference]:
+    def get_reported_in(assertion: Assertion) -> list[iriReference | Document]:
         """Get reported in information for an assertion
 
         :param assertion: CIViC assertion record
         :return: List of CIViC links to records which the assertion is reported in
         """
-        reported_in: list[iriReference] = [
+        reported_in: list[iriReference | Document] = [
             iriReference(f"{LINKS_URL}/assertion/{assertion.id}")
         ]
         for evidence_item in assertion.evidence_items or []:
-            reported_in.append(iriReference(f"{LINKS_URL}/evidence/{evidence_item.id}"))
+            civic_gks_source = CivicGksSource(
+                evidence_item.source,
+                urls=[f"{LINKS_URL}/evidence/{evidence_item.id}"],
+            )
+            reported_in.append(Document.model_validate(civic_gks_source))
         return reported_in
 
 

--- a/civicpy/tests/test_exports.py
+++ b/civicpy/tests/test_exports.py
@@ -482,23 +482,17 @@ def gks_aid6(
                         "system": "AMP/ASCO/CAP Guidelines, 2017",
                     },
                 },
-                "extensions": [
-                    {
-                        "name": "citations",
-                        "value": [
-                            "https://civicdb.org/links/evidence/2997",
-                            "https://civicdb.org/links/evidence/879",
-                            "https://civicdb.org/links/evidence/982",
-                            "https://civicdb.org/links/evidence/883",
-                            "https://civicdb.org/links/evidence/968",
-                            "https://civicdb.org/links/evidence/2629"
-                        ]
-                    }
-
-                ]
             }
         ],
-        "reportedIn": ["https://civicdb.org/links/assertion/6"],
+        "reportedIn": [
+            "https://civicdb.org/links/assertion/6",
+            "https://civicdb.org/links/evidence/2997",
+            "https://civicdb.org/links/evidence/879",
+            "https://civicdb.org/links/evidence/982",
+            "https://civicdb.org/links/evidence/883",
+            "https://civicdb.org/links/evidence/968",
+            "https://civicdb.org/links/evidence/2629",
+        ],
     }
     return VariantClinicalSignificanceStatement(**params)
 
@@ -867,12 +861,9 @@ class TestCivicGksClinSigAssertion(object):
         record = CivicGksClinSigAssertion(aid20)
         assert len(record.hasEvidenceLines) == 1
         assert record.hasEvidenceLines[0].hasEvidenceItems is None
-        assert len(record.hasEvidenceLines[0].extensions) == 1
-        assert record.hasEvidenceLines[0].extensions[0].model_dump(
-            exclude_none=True
-        ) == {
-            "name": "citations",
-            "value": ["https://civicdb.org/links/evidence/11881"],
+        assert {r.model_dump(exclude_none=True) for r in record.reportedIn or []} == {
+            "https://civicdb.org/links/evidence/11881",
+            "https://civicdb.org/links/assertion/20",
         }
 
 

--- a/civicpy/tests/test_exports.py
+++ b/civicpy/tests/test_exports.py
@@ -2,6 +2,7 @@ import re
 from copy import deepcopy
 from unittest.mock import PropertyMock, patch
 
+from ga4gh.vrs.models import iriReference
 import pytest
 from deepdiff import DeepDiff
 from ga4gh.va_spec.aac_2017 import (
@@ -406,6 +407,7 @@ def gks_source592():
         "pmid": "23982599",
         "type": "Document",
         "urls": [
+            "https://civicdb.org/links/evidence/2997",
             "https://civicdb.org/links/source/1725",
             "http://www.ncbi.nlm.nih.gov/pubmed/23982599",
         ],
@@ -443,17 +445,13 @@ def gks_eid2997(
         },
         "proposition": gks_therapeutic_proposition,
         "specifiedBy": gks_method,
-        "reportedIn": [gks_source592, "https://civicdb.org/links/evidence/2997"],
+        "reportedIn": [gks_source592],
     }
     return Statement(**params)
 
 
 @pytest.fixture(scope="module")
-def gks_aid6(
-    gks_method,
-    gks_therapeutic_proposition,
-    gks_eid2997,
-):
+def gks_aid6(gks_method, gks_therapeutic_proposition, gks_eid2997, gks_source592):
     """Create CIVIC AID6 GKS representation."""
     clin_sig_prop = deepcopy(gks_therapeutic_proposition)
     clin_sig_prop["predicate"] = "hasClinicalSignificanceFor"
@@ -497,12 +495,69 @@ def gks_aid6(
         ],
         "reportedIn": [
             "https://civicdb.org/links/assertion/6",
-            "https://civicdb.org/links/evidence/2997",
-            "https://civicdb.org/links/evidence/879",
-            "https://civicdb.org/links/evidence/982",
-            "https://civicdb.org/links/evidence/883",
-            "https://civicdb.org/links/evidence/968",
-            "https://civicdb.org/links/evidence/2629",
+            gks_source592,
+            {
+                "type": "Document",
+                "id": "civic.sid:592",
+                "name": "Sequist et al., 2013",
+                "title": "Phase III study of afatinib or cisplatin plus pemetrexed in patients with metastatic lung adenocarcinoma with EGFR mutations.",
+                "pmid": "23816960",
+                "urls": [
+                    "https://civicdb.org/links/evidence/879",
+                    "https://civicdb.org/links/source/592",
+                    "http://www.ncbi.nlm.nih.gov/pubmed/23816960",
+                ],
+            },
+            {
+                "type": "Document",
+                "id": "civic.sid:679",
+                "name": "Wu et al., 2014",
+                "title": "Afatinib versus cisplatin plus gemcitabine for first-line treatment of Asian patients with advanced non-small-cell lung cancer harbouring EGFR mutations (LUX-Lung 6): an open-label, randomised phase 3 trial.",
+                "pmid": "24439929",
+                "urls": [
+                    "https://civicdb.org/links/evidence/982",
+                    "https://civicdb.org/links/source/679",
+                    "http://www.ncbi.nlm.nih.gov/pubmed/24439929",
+                ],
+            },
+            {
+                "type": "Document",
+                "id": "civic.sid:594",
+                "name": "Yang et al., 2012",
+                "title": "Afatinib for patients with lung adenocarcinoma and epidermal growth factor receptor mutations (LUX-Lung 2): a phase 2 trial.",
+                "pmid": "22452895",
+                "urls": [
+                    "https://civicdb.org/links/evidence/883",
+                    "https://civicdb.org/links/source/594",
+                    "http://www.ncbi.nlm.nih.gov/pubmed/22452895",
+                ],
+            },
+            {
+                "type": "Document",
+                "id": "civic.sid:669",
+                "name": "Hirano et al., 2015",
+                "title": "In vitro modeling to determine mutation specificity of EGFR tyrosine kinase inhibitors against clinically relevant EGFR mutants in non-small-cell lung cancer.",
+                "pmid": "26515464",
+                "urls": [
+                    "https://civicdb.org/links/evidence/968",
+                    "https://civicdb.org/links/source/669",
+                    "http://www.ncbi.nlm.nih.gov/pubmed/26515464",
+                    "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4770737",
+                ],
+            },
+            {
+                "type": "Document",
+                "id": "civic.sid:1525",
+                "name": "Li et al., 2008",
+                "title": "BIBW2992, an irreversible EGFR/HER2 inhibitor highly effective in preclinical lung cancer models.",
+                "pmid": "18408761",
+                "urls": [
+                    "https://civicdb.org/links/evidence/2629",
+                    "https://civicdb.org/links/source/1525",
+                    "http://www.ncbi.nlm.nih.gov/pubmed/18408761",
+                    "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2748240",
+                ],
+            },
         ],
     }
     return VariantClinicalSignificanceStatement(**params)
@@ -872,10 +927,29 @@ class TestCivicGksClinSigAssertion(object):
         record = CivicGksClinSigAssertion(aid20)
         assert len(record.hasEvidenceLines) == 1
         assert record.hasEvidenceLines[0].hasEvidenceItems is None
-        assert {r.model_dump(exclude_none=True) for r in record.reportedIn or []} == {
-            "https://civicdb.org/links/evidence/11881",
+
+        reported_in = []
+        for r in record.reportedIn:
+            if isinstance(r, iriReference):
+                reported_in.append(r.root)
+            else:
+                reported_in.append(r.model_dump(exclude_none=True))
+
+        assert reported_in == [
             "https://civicdb.org/links/assertion/20",
-        }
+            {
+                "type": "Document",
+                "id": "civic.sid:4914",
+                "name": "Grimwade et al., 1998",
+                "title": "The importance of diagnostic cytogenetics on outcome in AML: analysis of 1,612 patients entered into the MRC AML 10 trial. The Medical Research Council Adult and Children's Leukaemia Working Parties.",
+                "pmid": "9746770",
+                "urls": [
+                    "https://civicdb.org/links/evidence/11881",
+                    "https://civicdb.org/links/source/4914",
+                    "http://www.ncbi.nlm.nih.gov/pubmed/9746770",
+                ],
+            },
+        ]
 
 
 class TestCivicGksDiagnosticAssertion(object):


### PR DESCRIPTION
close #219


* Originally in #226
* This removes 'citations' extension from statements, and instead stores these in the `reportedIn` field
* Use documents where possible, otherwise use IRIs