### PR TITLE
feat!: change extension names to use camel case convention

### DIFF
--- a/civicpy/exports/civic_gks_record.py
+++ b/civicpy/exports/civic_gks_record.py
@@ -491,7 +491,7 @@ class CivicGksMolecularProfile(CategoricalVariant):
                 if variant_type.url is not None
             ]
             if variant_types:
-                extensions.append(Extension(name="variant_types", value=variant_types))
+                extensions.append(Extension(name="variantTypes", value=variant_types))
 
             return ConceptMapping(
                 coding=Coding(
@@ -628,7 +628,7 @@ class CivicGksMolecularProfile(CategoricalVariant):
 
         for ext_name, ext_value in [
             (
-                "CIViC Molecular Profile Score",
+                "molecularProfileScore",
                 molecular_profile.molecular_profile_score,
             ),
             ("hgvsDescriptions", variant.hgvs_expressions),
@@ -654,7 +654,7 @@ class CivicGksMolecularProfile(CategoricalVariant):
             if all(v is not None for v in ext_value.values()):
                 extensions.append(
                     Extension(
-                        name="CIViC representative coordinate",
+                        name="representativeVariantCoordinates",
                         value=ext_value,
                     )
                 )
@@ -1313,7 +1313,7 @@ class _CivicGksAssertionMixin:
         :param approval: Approval for assertion
         :return: List of contributions, with one item containing when the approval was
             last reviewed an organization.
-            Will include an extension, `is_approved_vcep`.
+            Will include an ``isApprovedVcep`` extension.
         """
         organization: Organization = approval.organization
         return [
@@ -1326,7 +1326,7 @@ class _CivicGksAssertionMixin:
                     description=organization.description,
                     extensions=[
                         Extension(
-                            name="is_approved_vcep", value=organization.is_approved_vcep
+                            name="isApprovedVcep", value=organization.is_approved_vcep
                         )
                     ],
                 ),
@@ -1344,7 +1344,7 @@ class _CivicGksAssertionMixin:
         extensions = []
         if approval and approval.clinvar_accession:
             extensions.append(
-                Extension(name="clinvar_accession", value=approval.clinvar_accession)
+                Extension(name="clinvarAccession", value=approval.clinvar_accession)
             )
         return extensions
 

--- a/civicpy/tests/test_exports.py
+++ b/civicpy/tests/test_exports.py
@@ -129,7 +129,7 @@ def gks_contributions():
                 "type": "Agent",
                 "name": "CIViC",
                 "description": "The CIViC Organization (formerly “The McDonnell Genome Institute” CIViC organization) comprises the founders, developers, editors, curators, and administrators who build and maintain the knowledgebase, based at Washington University in St. Louis. This group is dedicated to ensuring that high-quality cancer variant interpretations are broadly accessible for precision oncology. One of their main roles is evaluating and synthesizing crowdsourced community contributions into formal clinical Assertions. Once these Assertions meet the strict criteria of the CIViC standard operating procedure, core approval members approve them for 1-star submission to the ClinVar CIViC organization.",
-                "extensions": [{"name": "is_approved_vcep", "value": False}],
+                "extensions": [{"name": "isApprovedVcep", "value": False}],
             },
             "activityType": "approval.last_reviewed",
             "date": "2026-04-24",
@@ -269,7 +269,7 @@ def gks_mpid33():
                     "extensions": [
                         {"name": "subtype", "value": "gene_variant"},
                         {
-                            "name": "variant_types",
+                            "name": "variantTypes",
                             "value": [
                                 {
                                     "coding": {
@@ -289,7 +289,7 @@ def gks_mpid33():
         ],
         "extensions": [
             {
-                "name": "CIViC representative coordinate",
+                "name": "representativeVariantCoordinates",
                 "value": {
                     "chromosome": "7",
                     "start": 55259515,
@@ -303,7 +303,7 @@ def gks_mpid33():
                 },
             },
             {
-                "name": "CIViC Molecular Profile Score",
+                "name": "molecularProfileScore",
                 "value": 379.0,
             },
             {
@@ -934,7 +934,7 @@ def civic_mpid113(ret_m918t_vrs, civic_mpid113_cdna_vrs, civic_mpid113_genomic_v
                     "extensions": [
                         {"name": "subtype", "value": "gene_variant"},
                         {
-                            "name": "variant_types",
+                            "name": "variantTypes",
                             "value": [
                                 {
                                     "coding": {
@@ -959,7 +959,7 @@ def civic_mpid113(ret_m918t_vrs, civic_mpid113_cdna_vrs, civic_mpid113_genomic_v
         ],
         "extensions": [
             {
-                "name": "CIViC representative coordinate",
+                "name": "representativeVariantCoordinates",
                 "value": {
                     "chromosome": "10",
                     "start": 43617416,
@@ -973,7 +973,7 @@ def civic_mpid113(ret_m918t_vrs, civic_mpid113_cdna_vrs, civic_mpid113_genomic_v
                 },
             },
             {
-                "name": "CIViC Molecular Profile Score",
+                "name": "molecularProfileScore",
                 "value": 139.0,
             },
             {
@@ -1643,7 +1643,7 @@ class TestCivicGksMolecularProfile(object):
             (
                 ext
                 for ext in gks_mp.extensions
-                if ext.name == "CIViC representative coordinate"
+                if ext.name == "representativeVariantCoordinates"
             ),
             None,
         )
@@ -2108,7 +2108,7 @@ class TestCivicGksRecord(object):
         )
         assert isinstance(record, VariantClinicalSignificanceStatement)
         assert [ext.model_dump(exclude_none=True) for ext in record.extensions] == [
-            {"name": "clinvar_accession", "value": "SCV007542591"}
+            {"name": "clinvarAccession", "value": "SCV007542591"}
         ]
 
     def test_assertion_invalid(self, aid117, mocked_normalizer):


### PR DESCRIPTION
close #243

* `variant_types` -> `variantTypes`
* `CIViC Molecular Profile Score` -> `molecularProfileScore`
* `CIViC representative coordinate` -> `representativeVariantCoordinates`
* `is_approved_vcep` -> `isApprovedVcep`
* `clinvar_accession` -> `clinvarAccession`