### PR TITLE
feat: add variation normalizer data proxy

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,8 +31,8 @@ jobs:
       - name: List installed packages
         run: |
           pip list
-      - name: Run tests
-        run: pytest --cov civicpy --cov-report term-missing
+      - name: Run CI tests
+        run: pytest --cov civicpy --cov-report term-missing -m "not live"
       - name: Coveralls
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/civicpy/exports/variation_normalizer.py
+++ b/civicpy/exports/variation_normalizer.py
@@ -1,0 +1,383 @@
+"""Normalize molecular profiles to VRS objects with the VICC Variation Normalizer.
+
+The included REST data proxy avoids the additional dependencies and resource setup
+required by the VICC Variation Normalizer Python API. Applications can subclass
+``VariationNormalizerDataProxy`` to use that API directly.
+"""
+
+import logging
+import re
+from abc import ABC, abstractmethod
+from os import getenv
+
+import requests
+from ga4gh.vrs.models import Allele, CopyNumberChange, VrsType
+from pydantic import ValidationError
+from pydantic.dataclasses import dataclass
+
+from civicpy.civic import GeneVariant, MolecularProfile
+
+_logger = logging.getLogger(__name__)
+
+MP_NAME_PATTERN = (
+    r"(?P<gene>[\w-]+)"
+    r"(?:\s+(?P<change>[^\s]+))?"
+    r"(?:\s+(?P<c_change>\(?c\..*\)?))?"
+)
+
+# Terms that are known to be unsupported by the VICC Variation Normalizer.
+UNSUPPORTED_CHANGE_TERMS = frozenset(
+    {
+        "mutation",
+        "exon",
+        "overexpression",
+        "frameshift",
+        "promoter",
+        "deletion",
+        "type",
+        "insertion",
+        "expression",
+        "duplication",
+        "copy",
+        "underexpression",
+        "number",
+        "variation",
+        "repeat",
+        "rearrangement",
+        "activation",
+        "mislocalization",
+        "translocation",
+        "wild",
+        "polymorphism",
+        "frame",
+        "shift",
+        "loss",
+        "function",
+        "levels",
+        "inactivation",
+        "snp",
+        "fusion",
+        "dup",
+        "truncation",
+        "homozygosity",
+        "gain",
+        "phosphorylation",
+    }
+)
+
+
+@dataclass
+class MolecularProfileNameComponents:
+    """Parsed molecular profile name components."""
+
+    gene: str
+    change: str | None
+    c_change: str | None
+
+
+class VariationNormalizerError(Exception):
+    """Raised when VICC Variation Normalizer processing fails."""
+
+
+class VariationNormalizerDataProxy(ABC):
+    """Abstraction for VICC Variation Normalizer backends.
+
+    Subclasses implement :meth:`normalize` to use a VICC Variation Normalizer backend.
+    :meth:`normalize_molecular_profile` provides the shared CIViC molecular profile
+    parsing and eligibility checks.
+    """
+
+    @abstractmethod
+    def normalize(
+        self,
+        expr: str,
+    ) -> Allele | CopyNumberChange | None:
+        """Normalize a variation expression with the configured VICC backend.
+
+        :param expr: Variation expression to normalize.
+        :return: Normalized VRS variation object if normalization succeeds.
+            Otherwise ``None``.
+        :raises VariationNormalizerError: If the request fails or the response is not
+            a valid VRS variation object.
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def _parse_molecular_profile_name(
+        molecular_profile_name: str,
+    ) -> MolecularProfileNameComponents | None:
+        """Parse components from a molecular profile name.
+
+        :param molecular_profile_name: CIViC Molecular Profile name.
+        :return: Molecular profile name components if the pattern matches.  Otherwise
+            ``None``.
+        """
+        match = re.fullmatch(
+            MP_NAME_PATTERN,
+            molecular_profile_name.strip(),
+        )
+
+        if not match:
+            return None
+
+        return MolecularProfileNameComponents(**match.groupdict())
+
+    @staticmethod
+    def _is_normalizable_change(
+        change: str,
+        molecular_profile_id: int,
+    ) -> bool:
+        """Determine whether a change is eligible for normalization.
+
+        :param change: Variant change component extracted from the molecular
+            profile name. This is what will be passed to the VICC Variation Normalizer.
+        :param molecular_profile_id: CIViC Molecular Profile ID. Used for logging.
+        :return: ``True`` if the change does not match a known unsupported pattern.
+            Otherwise ``False``. This is an eligibility filter, not a guarantee that
+            the VICC backend can normalize the expression.
+        """
+        change_lower = change.lower()
+
+        if (
+            change_lower.endswith("fs")
+            or any(c in change_lower for c in ("-", "/"))
+            or bool(set(change_lower.split()) & UNSUPPORTED_CHANGE_TERMS)
+        ):
+            _logger.warning(
+                "Unsupported molecular profile change for VICC Variation Normalizer. mpid=%i, change='%s'",
+                molecular_profile_id,
+                change,
+            )
+            return False
+
+        return True
+
+    def _build_normalization_query(
+        self,
+        molecular_profile: MolecularProfile,
+    ) -> str | None:
+        """Build a VICC Variation Normalizer query from a molecular profile.
+
+        :param molecular_profile: CIViC Molecular Profile.
+        :return: Query to use with the VICC Variation Normalizer when the profile
+            contains exactly one gene variant and a supported protein-level change.
+            Otherwise ``None``.
+        """
+        variants = molecular_profile.variants
+        mp_id = molecular_profile.id
+        mp_name = molecular_profile.name
+
+        if not variants:
+            _logger.warning("No variants found. mpid=%i, name='%s'", mp_id, mp_name)
+            return None
+
+        if len(variants) > 1:
+            _logger.warning(
+                "Complex molecular profiles are not supported. mpid=%i, name='%s'",
+                mp_id,
+                mp_name,
+            )
+            return None
+
+        if not isinstance(
+            variants[0],
+            GeneVariant,
+        ):
+            _logger.warning(
+                "Variant type '%s' is not supported. mpid=%i, name='%s'",
+                variants[0].__class__.__name__,
+                mp_id,
+                mp_name,
+            )
+            return None
+
+        components = self._parse_molecular_profile_name(mp_name)
+
+        if not components:
+            _logger.warning(
+                "Unable to parse molecular profile name. mpid=%i, name='%s'",
+                mp_id,
+                mp_name,
+            )
+            return None
+
+        if components.c_change:
+            _logger.warning(
+                "Molecular profiles containing cDNA changes are not supported. mpid=%i, name='%s'",
+                mp_id,
+                mp_name,
+            )
+            return None
+
+        change = components.change
+
+        if not change:
+            _logger.warning(
+                "No change component found in molecular profile name. mpid=%i, name='%s'",
+                mp_id,
+                mp_name,
+            )
+            return None
+
+        if not self._is_normalizable_change(
+            change,
+            molecular_profile.id,
+        ):
+            return None
+
+        return f"{components.gene} {change}"
+
+    def normalize_molecular_profile(
+        self,
+        molecular_profile: MolecularProfile,
+    ) -> Allele | CopyNumberChange | None:
+        """Normalize a CIViC Molecular Profile to a VRS variation.
+
+        :param molecular_profile: CIViC Molecular Profile.
+        :return: Normalized VRS variation if successful. Otherwise ``None``.
+        :raises VariationNormalizerError: If the configured VICC backend cannot
+            complete the normalization request.
+        """
+        expression = self._build_normalization_query(molecular_profile)
+        if not expression:
+            return None
+
+        normalized_variation = self.normalize(expression)
+
+        if not normalized_variation:
+            _logger.warning(
+                "VICC Variation Normalizer failed to normalize query. mpid=%i, query='%s'",
+                molecular_profile.id,
+                expression,
+            )
+            return None
+
+        return normalized_variation
+
+
+class VariationNormalizerRESTDataProxy(VariationNormalizerDataProxy):
+    """REST-backed data proxy for the VICC Variation Normalizer service.
+
+    By default, requests are sent to a local service at :attr:`DEFAULT_BASE_URL`.
+    Provide ``base_url`` or set :attr:`BASE_URL_ENV_VAR` to use another endpoint.
+    """
+
+    DEFAULT_BASE_URL = "http://127.0.0.1:8000/variation"
+    BASE_URL_ENV_VAR = "CIVICPY_VARIATION_NORMALIZER_URL"
+
+    def __init__(self, base_url: str | None = None):
+        """Initialize the VICC Variation Normalizer REST data proxy.
+
+        :param base_url: Base URL for the VICC Variation Normalizer REST service.
+            If not provided, ``CIVICPY_VARIATION_NORMALIZER_URL`` environment
+            variable will be used, followed by the ``DEFAULT_BASE_URL``.
+        """
+        self.base_url = (
+            base_url or getenv(self.BASE_URL_ENV_VAR) or self.DEFAULT_BASE_URL
+        )
+
+    @staticmethod
+    def _validate_vrs_variation(
+        variation: dict,
+        query: str,
+    ) -> Allele | CopyNumberChange | None:
+        """Validate and construct a VRS variation object.
+
+        :param variation: Variation object returned by the VICC Variation Normalizer.
+        :param query: Original normalization query. Used for logging.
+        :return: Validated VRS variation object if supported. Otherwise ``None``.
+        :raises VariationNormalizerError: If the variation cannot be validated as a
+            supported VRS variation object.
+        """
+        variation_type = variation.get("type")
+
+        try:
+            if variation_type == VrsType.ALLELE:
+                return Allele.model_validate(variation)
+
+            if variation_type == VrsType.CN_CHANGE:
+                return CopyNumberChange.model_validate(variation)
+
+            return None
+
+        except ValidationError as e:
+            msg = f"VICC Variation Normalizer returned invalid VRS variation object. query={query!r}, variation_type={variation_type!r}"
+            _logger.exception(msg)
+            raise VariationNormalizerError(msg) from e
+
+    def normalize(
+        self,
+        expr: str,
+    ) -> Allele | CopyNumberChange | None:
+        """Normalize a variation expression via the ``/normalize`` endpoint.
+
+        :param expr: Variation expression to normalize.
+        :return: Normalized VRS variation object if normalization succeeds.
+            Otherwise ``None``.
+        :raises VariationNormalizerError: If the request fails or the response is not
+            a valid VRS variation object.
+        """
+        try:
+            response = requests.get(
+                f"{self.base_url}/normalize",
+                params={"q": expr},
+                timeout=15,
+            )
+            response.raise_for_status()
+
+        except requests.exceptions.HTTPError as e:
+            status_code = e.response.status_code if e.response is not None else None
+            msg = (
+                "VICC Variation Normalizer returned unexpected HTTP status. "
+                f"query={expr!r}, "
+                f"status_code={status_code}"
+            )
+            _logger.exception(msg)
+            raise VariationNormalizerError(msg) from e
+
+        except requests.exceptions.RequestException as e:
+            msg = (
+                f"VICC Variation Normalizer request failed. query={expr!r}, error={e!s}"
+            )
+            _logger.exception(msg)
+            raise VariationNormalizerError(msg) from e
+
+        try:
+            data = response.json()
+        except ValueError as e:
+            msg = f"VICC Variation Normalizer returned invalid JSON. query={expr!r}"
+            _logger.exception(msg)
+            raise VariationNormalizerError(msg) from e
+
+        if not isinstance(data, dict):
+            msg = (
+                "VICC Variation Normalizer returned an invalid response payload. "
+                f"query={expr!r}"
+            )
+            _logger.error(msg)
+            raise VariationNormalizerError(msg)
+
+        variation = data.get("variation")
+        if variation is None:
+            _logger.warning(
+                "VICC Variation Normalizer returned no variation object. query=%r",
+                expr,
+            )
+            return None
+
+        if not isinstance(variation, dict):
+            msg = (
+                "VICC Variation Normalizer returned an invalid variation object. "
+                f"query={expr!r}"
+            )
+            _logger.error(msg)
+            raise VariationNormalizerError(msg)
+
+        variation = variation.copy()
+        variation["name"] = expr
+        variation.pop("extensions", None)
+
+        return self._validate_vrs_variation(
+            variation,
+            expr,
+        )

--- a/civicpy/tests/conftest.py
+++ b/civicpy/tests/conftest.py
@@ -1,0 +1,55 @@
+from civicpy.civic import load_cache, get_molecular_profile_by_id
+import pytest
+from ga4gh.vrs.models import Allele, CopyNumberChange
+
+
+@pytest.fixture(scope="module")
+def braf_v600e_vrs():
+    params = {
+        "name": "BRAF V600E",
+        "id": "ga4gh:VA.j4XnsLZcdzDIYa5pvvXM7t1wn9OITr0L",
+        "type": "Allele",
+        "digest": "j4XnsLZcdzDIYa5pvvXM7t1wn9OITr0L",
+        "location": {
+            "id": "ga4gh:SL.t-3DrWALhgLdXHsupI-e-M00aL3HgK3y",
+            "type": "SequenceLocation",
+            "digest": "t-3DrWALhgLdXHsupI-e-M00aL3HgK3y",
+            "sequenceReference": {
+                "type": "SequenceReference",
+                "refgetAccession": "SQ.cQvw4UsHHRRlogxbWCB8W-mKD4AraM9y",
+            },
+            "start": 599,
+            "end": 600,
+            "sequence": "V",
+        },
+        "state": {"type": "LiteralSequenceExpression", "sequence": "E"},
+    }
+    return Allele(**params)
+
+
+@pytest.fixture(scope="session")
+def braf_amplification_vrs():
+    params = {
+        "name": "BRAF Amplification",
+        "id": "ga4gh:CX.h7unj-f_djER28-h2Q6Prvo3C90O4d3M",
+        "type": "CopyNumberChange",
+        "digest": "h7unj-f_djER28-h2Q6Prvo3C90O4d3M",
+        "location": {
+            "id": "ga4gh:SL.0nPwKHYNnTmJ06G-gSmz8BEhB_NTp-0B",
+            "type": "SequenceLocation",
+            "digest": "0nPwKHYNnTmJ06G-gSmz8BEhB_NTp-0B",
+            "sequenceReference": {
+                "type": "SequenceReference",
+                "refgetAccession": "SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul",
+            },
+            "start": 140713327,
+            "end": 140924929,
+        },
+        "copyChange": "high-level gain",
+    }
+    return CopyNumberChange(**params)
+
+
+@pytest.fixture(scope="module")
+def v600e_mp():
+    return get_molecular_profile_by_id(12)

--- a/civicpy/tests/exports/test_variation_normalizer.py
+++ b/civicpy/tests/exports/test_variation_normalizer.py
@@ -1,0 +1,239 @@
+"""Test that VICC Variation Normalizer data proxy works correctly."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+from requests.exceptions import HTTPError, RequestException
+
+from civicpy.civic import get_molecular_profile_by_id
+from civicpy.exports.variation_normalizer import (
+    VariationNormalizerError,
+    VariationNormalizerRESTDataProxy,
+)
+
+
+@pytest.fixture
+def rest_dp():
+    return VariationNormalizerRESTDataProxy()
+
+
+BRAF_V600E_QUERY = "BRAF V600E"
+
+
+class TestVariationNormalizerRESTDataProxy(object):
+    """Test that VariationNormalizerRESTDataProxy works as expected
+
+    These are mocked for CI purposes
+    """
+
+    @patch("requests.get")
+    @pytest.mark.parametrize(
+        ("query", "expected_vrs_fixture"),
+        [
+            (BRAF_V600E_QUERY, "braf_v600e_vrs"),
+            ("BRAF Amplification", "braf_amplification_vrs"),
+        ],
+    )
+    def test_normalize_success(
+        self, mock_get, request, rest_dp, query, expected_vrs_fixture
+    ):
+
+        expected_vrs = request.getfixturevalue(expected_vrs_fixture)
+
+        mock_response = Mock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {
+            "variation": expected_vrs.model_dump(exclude_none=True)
+        }
+        mock_get.return_value = mock_response
+
+        result = rest_dp.normalize(query)
+        assert result == expected_vrs
+        mock_get.assert_called_once_with(
+            f"{rest_dp.base_url}/normalize",
+            params={"q": query},
+            timeout=15,
+        )
+
+    @patch("requests.get")
+    def test_normalize_returns_none(self, mock_get, rest_dp):
+        mock_response = Mock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {"variation": None}
+        mock_get.return_value = mock_response
+
+        result = rest_dp.normalize(BRAF_V600E_QUERY)
+        assert result is None
+
+    @patch("requests.get")
+    def test_normalize_returns_no_variation_key(self, mock_get, caplog, rest_dp):
+        mock_response = Mock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {"variant": {None}}
+        mock_get.return_value = mock_response
+
+        result = rest_dp.normalize(BRAF_V600E_QUERY)
+        assert result is None
+        assert (
+            "VICC Variation Normalizer returned no variation object. query='BRAF V600E'"
+            in caplog.text
+        )
+
+    @patch("requests.get")
+    @pytest.mark.parametrize(
+        ("payload", "error"),
+        [
+            (
+                ValueError("invalid JSON"),
+                "VICC Variation Normalizer returned invalid JSON",
+            ),
+            ([], "VICC Variation Normalizer returned an invalid response payload"),
+            (
+                {"variation": []},
+                "VICC Variation Normalizer returned an invalid variation object",
+            ),
+        ],
+    )
+    def test_normalize_invalid_response(self, mock_get, rest_dp, payload, error):
+        mock_response = Mock()
+        mock_response.raise_for_status.return_value = None
+        if isinstance(payload, Exception):
+            mock_response.json.side_effect = payload
+        else:
+            mock_response.json.return_value = payload
+        mock_get.return_value = mock_response
+
+        with pytest.raises(VariationNormalizerError, match=error):
+            rest_dp.normalize(BRAF_V600E_QUERY)
+
+    @patch("requests.get")
+    def test_normalize_does_not_mutate_response_variation(self, mock_get, rest_dp):
+        response_variation = {"type": "UnsupportedVariation"}
+        mock_response = Mock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {"variation": response_variation}
+        mock_get.return_value = mock_response
+
+        assert rest_dp.normalize(BRAF_V600E_QUERY) is None
+        assert response_variation == {"type": "UnsupportedVariation"}
+
+    @patch("requests.get")
+    def test_normalize_http_error(self, mock_get, rest_dp):
+        mock_response = Mock()
+        mock_response.raise_for_status.side_effect = HTTPError(
+            response=Mock(status_code=500)
+        )
+        mock_get.return_value = mock_response
+
+        with pytest.raises(
+            VariationNormalizerError,
+            match="VICC Variation Normalizer returned unexpected HTTP status. query='BRAF V600E', status_code=500",
+        ):
+            rest_dp.normalize(BRAF_V600E_QUERY)
+
+    @patch("requests.get")
+    def test_normalize_request_error(self, mock_get, rest_dp):
+        mock_get.side_effect = RequestException("Connection failed")
+
+        with pytest.raises(
+            VariationNormalizerError,
+            match="VICC Variation Normalizer request failed. query='BRAF V600E'",
+        ):
+            rest_dp.normalize(BRAF_V600E_QUERY)
+
+    @patch("requests.get")
+    def test_normalize_validation_error(self, mock_get, rest_dp):
+        mock_response = Mock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {"variation": {"type": "Allele"}}
+        mock_get.return_value = mock_response
+
+        with pytest.raises(
+            VariationNormalizerError,
+            match="VICC Variation Normalizer returned invalid VRS variation object. query='BRAF V600E', variation_type='Allele'",
+        ):
+            rest_dp.normalize(BRAF_V600E_QUERY)
+
+    @patch("requests.get")
+    def test_normalize_molecular_profile(
+        self, mock_get, rest_dp, braf_v600e_vrs, v600e_mp
+    ):
+        mock_response = Mock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {
+            "variation": braf_v600e_vrs.model_dump(exclude_none=True)
+        }
+        mock_get.return_value = mock_response
+
+        result = rest_dp.normalize_molecular_profile(v600e_mp)
+        assert result == braf_v600e_vrs
+
+    @pytest.mark.parametrize(
+        ("mp_id", "log_msg"),
+        [
+            (
+                1615,
+                "Molecular profiles containing cDNA changes are not supported. mpid=1615, name='VHL R167Q (c.500G>A)'",
+            ),
+            (
+                332,
+                "Unsupported molecular profile change for VICC Variation Normalizer. mpid=332, change='Mutation'",
+            ),
+            (
+                2995,
+                "Variant type 'FusionVariant' is not supported. mpid=2995, name='RUNX1::RUNX1T1 Fusion'",
+            ),
+            (
+                5117,
+                "Variant type 'FactorVariant' is not supported. mpid=5117, name='TMB High'",
+            ),
+            (
+                5879,
+                "Variant type 'RegionVariant' is not supported. mpid=5879, name='1q21.2 Amplification'",
+            ),
+            (
+                4344,
+                "Complex molecular profiles are not supported. mpid=4344, name='EZH2 Y646S OR EZH2 Y646F OR EZH2 Y646H OR EZH2 Y646C OR EZH2 Y646N OR EZH2 A692V OR EZH2 A682G'",
+            ),
+        ],
+    )
+    def test_not_supported(self, caplog, rest_dp, mp_id, log_msg):
+        rest_dp.normalize = Mock()
+
+        mp = get_molecular_profile_by_id(mp_id)
+        result = rest_dp.normalize_molecular_profile(mp)
+        rest_dp.normalize.assert_not_called()
+        assert result is None
+        assert log_msg in caplog.text
+
+    @pytest.mark.parametrize(
+        "mp_id",
+        [
+            302,
+        ],
+    )
+    def test_normalize_called(self, rest_dp, mp_id):
+        rest_dp.normalize = Mock(return_value=None)
+
+        mp = get_molecular_profile_by_id(mp_id)
+        rest_dp.normalize_molecular_profile(mp)
+        rest_dp.normalize.assert_called_once_with("ERBB2 Amplification")
+
+
+@pytest.mark.live
+class TestVariationNormalizerRESTDataProxyLive(object):
+    """Test that VariationNormalizerRESTDataProxy works as expected
+
+    Note: This hits the live VICC Variation Normalizer service.
+    """
+
+    @pytest.mark.parametrize(
+        ("query", "expected_vrs_fixture"),
+        [
+            (BRAF_V600E_QUERY, "braf_v600e_vrs"),
+            ("BRAF Amplification", "braf_amplification_vrs"),
+        ],
+    )
+    def test_normalize(self, request, query, expected_vrs_fixture, rest_dp):
+        result = rest_dp.normalize(query)
+        assert result == request.getfixturevalue(expected_vrs_fixture)

--- a/docs/exports.rst
+++ b/docs/exports.rst
@@ -240,6 +240,37 @@ CivicGksWriter
 .. autoclass:: civicpy.exports.civic_gks_writer.CivicGksWriter
    :members:
 
+Variation Normalization
+~~~~~~~~~~~~~~~~~~~~~~~
+
+CIViC simple molecular profiles can be normalized to GA4GH VRS Allele or Copy
+Number Change objects using the `VICC Variation Normalizer`_.
+
+``VariationNormalizerDataProxy`` supports normalization through either the REST
+API or the Python API. CIViCpy includes a REST implementation. To use the Python
+API directly, subclass ``VariationNormalizerDataProxy`` and implement
+``normalize``. The base class handles the shared profile parsing and eligibility
+checks.
+
+``VariationNormalizerRESTDataProxy`` is the included implementation for the VICC
+Variation Normalizer REST API. It uses ``http://127.0.0.1:8000/variation`` by default.
+Pass a ``base_url`` argument or set ``CIVICPY_VARIATION_NORMALIZER_URL`` to use a
+different endpoint.
+
+.. _VICC Variation Normalizer: https://github.com/cancervariants/variation-normalization/
+
+VariationNormalizerDataProxy
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. autoclass:: civicpy.exports.variation_normalizer.VariationNormalizerDataProxy
+   :members:
+
+VariationNormalizerRESTDataProxy
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. autoclass:: civicpy.exports.variation_normalizer.VariationNormalizerRESTDataProxy
+   :members:
+
 Examples
 ~~~~~~~~
 
@@ -294,4 +325,3 @@ ready for submission to ClinVar.::
                 records.append(gks_record)
 
     CivicGksWriter(Path("gks.json"), records)
-

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    live: tests requiring a live Variation Normalizer service


### PR DESCRIPTION
needed for #209

- Migrate work from MetaKB
- Adds Variation Normalizer REST Data Proxy to retrieve normalized VRS variations (only supports Allele and CopyNumberChange)